### PR TITLE
fix(core): cannot get component method defined from init

### DIFF
--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -703,12 +703,7 @@ export class Component<
               }
               comp._$methodMap[exportedKey] = exportItem
               if (options.writeFieldsToNode) {
-                Object.defineProperty(comp, exportedKey, {
-                  enumerable: true,
-                  value: exportItem,
-                  writable: true,
-                  configurable: true,
-                })
+                ;(comp as { [key: string]: GeneralFuncType })[exportedKey] = exportItem
               }
             }
           }
@@ -952,6 +947,14 @@ export class Component<
     TMethod extends MethodList,
   >(comp: Component<TData, TProperty, TMethod>, methodName: string): GeneralFuncType | undefined {
     return comp._$methodMap[methodName]
+  }
+
+  /** Call a method */
+  callMethod<T extends string>(
+    methodName: T,
+    ...args: Parameters<MethodList[T]>
+  ): ReturnType<MethodList[T]> | undefined {
+    return this._$methodMap[methodName]?.call(this, ...args)
   }
 
   /**

--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -702,6 +702,14 @@ export class Component<
                 comp._$methodMap = Object.create(comp._$methodMap) as MethodList
               }
               comp._$methodMap[exportedKey] = exportItem
+              if (options.writeFieldsToNode) {
+                Object.defineProperty(comp, exportedKey, {
+                  enumerable: true,
+                  value: exportItem,
+                  writable: true,
+                  configurable: true,
+                })
+              }
             }
           }
         }
@@ -943,7 +951,7 @@ export class Component<
     TProperty extends PropertyList,
     TMethod extends MethodList,
   >(comp: Component<TData, TProperty, TMethod>, methodName: string): GeneralFuncType | undefined {
-    return comp._$behavior._$methodMap[methodName]
+    return comp._$methodMap[methodName]
   }
 
   /**

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -887,7 +887,7 @@ export class ProcGenWrapper {
       const host = elem.ownerShadowRoot!.getHostNode()
       let ret: boolean | undefined
       const methodCaller = host.getMethodCaller() as { [key: string]: unknown }
-      const f = typeof handler === 'function' ? handler : host._$methodMap[handler]
+      const f = typeof handler === 'function' ? handler : Component.getMethod(host, handler)
       if (typeof f === 'function') {
         ret = (f as (ev: ShadowedEvent<unknown>) => boolean | undefined).call(methodCaller, ev)
       }

--- a/glass-easel/tests/core/misc.test.ts
+++ b/glass-easel/tests/core/misc.test.ts
@@ -216,7 +216,7 @@ describe('event', () => {
 })
 
 describe('component utils', () => {
-  test('#getMethodsFromDef #getMethod', () => {
+  test('#getMethodsFromDef #getMethod #callMethod', () => {
     const compDef = glassEasel.Component.register(
       {
         methods: {
@@ -233,9 +233,10 @@ describe('component utils', () => {
     expect(glassEasel.Component.getMethodsFromDef(compDef.general()).abc!()).toBe('abc')
     const comp = glassEasel.createElement('root', compDef.general())
     expect(glassEasel.Component.getMethod(comp.general(), 'abc')!()).toBe('abc')
+    expect(comp.callMethod('abc')).toBe('abc')
   })
 
-  test('#getMethodsFromDef #getMethod (in init function)', () => {
+  test('#getMethodsFromDef #getMethod #callMethod (in init function)', () => {
     const compDef = componentSpace
       .define()
       .init(({ method }) => {
@@ -251,6 +252,7 @@ describe('component utils', () => {
     expect(glassEasel.Component.getMethodsFromDef(compDef.general()).abc).toBe(undefined)
     const comp = glassEasel.createElement('root', compDef.general())
     expect(glassEasel.Component.getMethod(comp.general(), 'abc')!()).toBe('abc')
+    expect(comp.callMethod('abc')).toBe('abc')
   })
 
   test('#isInnerDataExcluded', () => {

--- a/glass-easel/tests/core/misc.test.ts
+++ b/glass-easel/tests/core/misc.test.ts
@@ -235,6 +235,24 @@ describe('component utils', () => {
     expect(glassEasel.Component.getMethod(comp.general(), 'abc')!()).toBe('abc')
   })
 
+  test('#getMethodsFromDef #getMethod (in init function)', () => {
+    const compDef = componentSpace
+      .define()
+      .init(({ method }) => {
+        const abc = method(() => 'abc')
+        return {
+          abc,
+        }
+      })
+      .registerComponent()
+    expect(compDef.isPrepared()).toBe(false)
+    compDef.prepare()
+    expect(compDef.isPrepared()).toBe(true)
+    expect(glassEasel.Component.getMethodsFromDef(compDef.general()).abc).toBe(undefined)
+    const comp = glassEasel.createElement('root', compDef.general())
+    expect(glassEasel.Component.getMethod(comp.general(), 'abc')!()).toBe('abc')
+  })
+
   test('#isInnerDataExcluded', () => {
     const compDef = glassEasel.Component.register(
       {


### PR DESCRIPTION
If a component method is defined and returned in `init` function, it cannot be found in the component even if `writeFieldsToNode` option is enabled, and the `Component.getMethod` does not returns it. This PR fix this problem.