### PR TITLE
fix(core): destroy backend element earilier

### DIFF
--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -405,6 +405,9 @@ export class Element implements NodeCast {
 
   private static checkAndCallDetached(node: Node) {
     const callFunc = function callFunc(node: Node) {
+      if (node._$destroyOnDetach) {
+        node.destroyBackendElement()
+      }
       if (node instanceof Element && node._$attached) {
         node.childNodes.forEach(callFunc)
         if (node instanceof Component) {
@@ -429,9 +432,6 @@ export class Element implements NodeCast {
         } else {
           node._$attached = false
         }
-      }
-      if (node._$destroyOnDetach) {
-        node.destroyBackendElement()
       }
     }
     callFunc(node)


### PR DESCRIPTION
When a data update applies in `detached` lifetime, current implementation destroys children's backend elements before parent's element, which leads to backend call like `backendParent.spliceRemove(null, 1)`, and may cause unexpected results in backend.

This Pull Request destroys parent's backend element first, to prevent cases like this.