### PR TITLE
Modify backend protocol for event-listener & context

### DIFF
--- a/glass-easel/src/backend/backend_protocol.ts
+++ b/glass-easel/src/backend/backend_protocol.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 
-import { EventBubbleStatus, EventOptions } from '../event'
+import { EventBubbleStatus, EventOptions, MutLevel } from '../event'
 import { safeCallback } from '../func_arr'
 import {
   BackendMode,
@@ -75,17 +75,19 @@ export interface Element extends Partial<suggestedBackend.Element> {
   clearClasses(): void
   setAttribute(name: string, value: unknown): void
   removeAttribute(name: string): void
+  setDataset(name: string, value: unknown): void
   setText(content: string): void
   getBoundingClientRect(cb: (res: BoundingClientRect) => void): void
   getScrollOffset(cb: (res: ScrollOffset) => void): void
-  setEventDefaultPrevented(type: string, enabled: boolean): void
   setModelBindingStat(attributeName: string, listener: ((newValue: unknown) => void) | null): void
+  setListenerStats(type: string, capture: boolean, mutLevel: MutLevel): void
   createIntersectionObserver(
     relativeElement: Element | null,
     relativeElementMargin: string,
     thresholds: number[],
     listener: (res: IntersectionStatus) => void,
   ): Observer
+  getContext(cb: (res: unknown) => void): void
 }
 
 export interface ShadowRootContext extends Element {
@@ -309,6 +311,10 @@ export class EmptyBackendElement implements Element {
     // empty
   }
 
+  setDataset(_name: string, _value: unknown): void {
+    // empty
+  }
+
   setText(_content: string): void {
     // empty
   }
@@ -335,7 +341,7 @@ export class EmptyBackendElement implements Element {
     }, 0)
   }
 
-  setEventDefaultPrevented(_type: string, _enabled: boolean): void {
+  setListenerStats(_type: string, _capture: boolean, _mutLevel: MutLevel): void {
     // empty
   }
 
@@ -357,6 +363,10 @@ export class EmptyBackendElement implements Element {
         /* empty */
       },
     }
+  }
+
+  getContext(cb: (res: unknown) => void): void {
+    cb(null)
   }
 }
 

--- a/glass-easel/src/backend/composed_backend_protocol.ts
+++ b/glass-easel/src/backend/composed_backend_protocol.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 
-import { EventOptions, EventBubbleStatus } from '../event'
+import { EventOptions, EventBubbleStatus, MutLevel } from '../event'
 import { safeCallback } from '../func_arr'
 import {
   BackendMode,
@@ -63,14 +63,15 @@ export interface Element extends Partial<suggestedBackend.Element> {
   setText(content: string): void
   getBoundingClientRect(cb: (res: BoundingClientRect) => void): void
   getScrollOffset(cb: (res: ScrollOffset) => void): void
-  setEventDefaultPrevented(type: string, enabled: boolean): void
   setModelBindingStat(attributeName: string, listener: ((newValue: unknown) => void) | null): void
+  setListenerStats(type: string, capture: boolean, mutLevel: MutLevel): void
   createIntersectionObserver(
     relativeElement: Element | null,
     relativeElementMargin: string,
     thresholds: number[],
     listener: (res: IntersectionStatus) => void,
   ): Observer
+  getContext(cb: (res: unknown) => void): void
 }
 
 /** An empty backend implementation */
@@ -275,7 +276,7 @@ export class EmptyComposedBackendElement implements Element {
     }, 0)
   }
 
-  setEventDefaultPrevented(_type: string, _enabled: boolean): void {
+  setListenerStats(_type: string, _capture: boolean, _mutLevel: MutLevel): void {
     // empty
   }
 
@@ -297,5 +298,9 @@ export class EmptyComposedBackendElement implements Element {
         /* empty */
       },
     }
+  }
+
+  getContext(cb: (res: unknown) => void): void {
+    cb(null)
   }
 }

--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -10,6 +10,7 @@ import {
   EventOptions,
   EventTarget,
   FinalChanged,
+  MutLevel,
 } from './event'
 import { triggerWarning } from './func_arr'
 import { ParsedSelector } from './selector'
@@ -1984,24 +1985,47 @@ export class Element implements NodeCast {
     Event.dispatchEvent(this, ev)
   }
 
-  private _$updateEventDefaultPrevented(name: string, enabled: boolean) {
-    if (!this._$backendElement) return
+  /* @internal */
+  private _$setListenerStats(
+    name: string,
+    finalChanged: FinalChanged,
+    options: EventListenerOptions = {},
+  ) {
+    const capture = !!options.capture || !!options.useCapture
+    let mutLevel: MutLevel
+    switch (finalChanged) {
+      case FinalChanged.None:
+        mutLevel = MutLevel.None
+        break
+      case FinalChanged.Mut:
+        mutLevel = MutLevel.Mut
+        break
+      case FinalChanged.Final:
+        mutLevel = MutLevel.Final
+        break
+      default:
+        return
+    }
     if (BM.DOMLIKE || (BM.DYNAMIC && this.getBackendMode() === BackendMode.Domlike)) {
-      ;(this._$nodeTreeContext as domlikeBackend.Context).setElementEventDefaultPrevented(
+      ;(this._$nodeTreeContext as domlikeBackend.Context).setListenerStats(
         this._$backendElement as domlikeBackend.Element,
         name,
-        enabled,
+        capture,
+        mutLevel,
       )
     } else {
-      ;(this._$backendElement as backend.Element).setEventDefaultPrevented(name, enabled)
+      ;(this._$backendElement as backend.Element | composedBackend.Element).setListenerStats(
+        name,
+        capture,
+        mutLevel,
+      )
     }
   }
 
   /** Add an event listener on the element */
   addListener(name: string, func: EventListener<unknown>, options?: EventListenerOptions) {
     const finalChanged = this._$eventTarget.addListener(name, func, options)
-    if (finalChanged === FinalChanged.Init) this._$updateEventDefaultPrevented(name, false)
-    else if (finalChanged === FinalChanged.Added) this._$updateEventDefaultPrevented(name, true)
+    this._$setListenerStats(name, finalChanged, options)
     if (this instanceof Component && this._$definition._$options.listenerChangeLifetimes) {
       this.triggerLifetime('listenerChange', [true, name, func, options])
     }
@@ -2011,7 +2035,7 @@ export class Element implements NodeCast {
   removeListener(name: string, func: EventListener<unknown>, options?: EventListenerOptions) {
     const finalChanged = this._$eventTarget.removeListener(name, func, options)
     if (finalChanged === FinalChanged.Failed) return
-    if (finalChanged !== FinalChanged.NotChanged) this._$updateEventDefaultPrevented(name, false)
+    this._$setListenerStats(name, finalChanged, options)
     if (this instanceof Component && this._$definition._$options.listenerChangeLifetimes) {
       this.triggerLifetime('listenerChange', [false, name, func, options])
     }
@@ -2065,6 +2089,15 @@ export class Element implements NodeCast {
       delete this._$nodeAttributes[name]
     }
     if (this._$backendElement) this._$backendElement.removeAttribute(name)
+  }
+
+  /** Set a dataset on the element */
+  setDataset(name: string, value: unknown) {
+    this.dataset[name] = value
+
+    if (BM.SHADOW || (BM.DYNAMIC && this.getBackendMode() === BackendMode.Shadow)) {
+      ;(this._$backendElement as backend.Element).setDataset(name, value)
+    }
   }
 
   /** Set a mark on the element */
@@ -2648,5 +2681,21 @@ export class Element implements NodeCast {
       )
     }
     return null
+  }
+
+  /**
+   * Get an interactive context
+   */
+  getContext(cb: (res: unknown) => void): void {
+    const backendElement = this._$backendElement
+    if (!backendElement) return
+    if (BM.DOMLIKE || (BM.DYNAMIC && this.getBackendMode() === BackendMode.Domlike)) {
+      ;(this._$nodeTreeContext as domlikeBackend.Context).getContext(
+        backendElement as domlikeBackend.Element,
+        cb,
+      )
+    } else {
+      ;(backendElement as backend.Element).getContext(cb)
+    }
   }
 }

--- a/glass-easel/src/index.ts
+++ b/glass-easel/src/index.ts
@@ -32,6 +32,7 @@ export {
   EventOptions,
   EventListener,
   EventListenerOptions,
+  MutLevel as EventMutLevel,
 } from './event'
 export * as typeUtils from './component_params'
 export {

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -894,7 +894,7 @@ export class ProcGenWrapper {
 
   // set dataset
   d(elem: Element, name: string, v: unknown) {
-    elem.dataset[name] = v
+    elem.setDataset(name, v)
   }
 
   // set mark

--- a/glass-easel/tests/backend/domlike.test.ts
+++ b/glass-easel/tests/backend/domlike.test.ts
@@ -14,14 +14,8 @@ componentSpace.defineComponent({
 
 describe('domlike backend', () => {
   beforeAll(() => {
-    domBackend.onEvent((target: glassEasel.domlikeBackend.Element, type, detail, options) => {
-      let cur = target as Element & glassEasel.domlikeBackend.Element
-      while (cur && !cur.__wxElement) {
-        cur = cur.parentNode as Element & glassEasel.domlikeBackend.Element
-      }
-      if (!cur) return
-      const ev = new glassEasel.Event(type, detail, options)
-      glassEasel.Event.dispatchEvent(target.__wxElement as any, ev)
+    domBackend.onEvent((target, type, detail, options) => {
+      glassEasel.Event.triggerEvent(target, type, detail, options)
     })
   })
 


### PR DESCRIPTION
1. add `setDataset` for shadow backend
2. add `setListenerStats` replacing `setEventDefaultPrevented`
3. add `getContext` for elements with interactive context such as `<canvas />`
4. `FinalChanged` now representing the final state itself instead of state transitioning