### PR TITLE
Fix caret class on root

### DIFF
--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -49,7 +49,7 @@ import {
 } from './data_proxy'
 import { Relation, generateRelationDefinitionGroup, RelationDefinitionGroup } from './relation'
 import { Template, TemplateEngine, TemplateInstance } from './template_engine'
-import { ClassList } from './class_list'
+import { ClassList, StyleScopeManager } from './class_list'
 import { GeneralBackendContext, GeneralBackendElement } from './node'
 import { DataPath, parseSinglePath, parseMultiPaths } from './data_path'
 import { ExternalShadowRoot } from './external_shadow_tree'
@@ -543,7 +543,19 @@ export class Component<
         externalClassAlias[externalClasses[i]!] = null
       }
     }
-    comp.classList = new ClassList(comp, externalClassAlias)
+    const styleScope = owner
+      ? owner.getHostNode().getComponentOptions().styleScope
+      : StyleScopeManager.globalScope()
+    const extraStyleScope = owner
+      ? owner.getHostNode().getComponentOptions().extraStyleScope ?? undefined
+      : undefined
+    comp.classList = new ClassList(
+      comp,
+      externalClassAlias,
+      owner ? owner.getHostNode().classList : null,
+      styleScope,
+      extraStyleScope,
+    )
     if (backendElement) {
       const styleScope = owner
         ? owner.getHostNode()._$definition._$options.styleScope

--- a/glass-easel/src/native_node.ts
+++ b/glass-easel/src/native_node.ts
@@ -2,7 +2,7 @@ import * as backend from './backend/backend_protocol'
 import * as composedBackend from './backend/composed_backend_protocol'
 import * as domlikeBackend from './backend/domlike_backend_protocol'
 import { globalOptions } from './global_options'
-import { ClassList } from './class_list'
+import { ClassList, StyleScopeManager } from './class_list'
 import { Element } from './element'
 import { ShadowRoot } from './shadow_root'
 import { GeneralBackendElement } from '.'
@@ -40,7 +40,16 @@ export class NativeNode extends Element {
       backendElement = backend.createElement(tagName, stylingName ?? tagName)
     }
     node._$initialize(false, backendElement, owner, nodeTreeContext)
-    node.classList = new ClassList(node, null)
+    const ownerOptions = owner.getHostNode().getComponentOptions()
+    const styleScope = owner ? ownerOptions.styleScope : StyleScopeManager.globalScope()
+    const extraStyleScope = owner ? ownerOptions.extraStyleScope ?? undefined : undefined
+    node.classList = new ClassList(
+      node,
+      null,
+      owner ? owner.getHostNode().classList : null,
+      styleScope,
+      extraStyleScope,
+    )
     if (owner && backendElement) {
       const styleScope = owner.getHostNode()._$definition._$options.styleScope
       if (styleScope) {

--- a/glass-easel/tests/legacy/component.test.js
+++ b/glass-easel/tests/legacy/component.test.js
@@ -1017,7 +1017,7 @@ describe('Component', function () {
         options: {
           styleScope: componentSpace.styleScopeManager.register('a'),
         },
-        template: '<span id="a" class="a ^a ^^aa ~a"></span>',
+        template: '<span id="a" class="a ^a1 ^^a2 ^^^a3 ^^^^a4 ~a5"></span>',
       })
       regElem({
         is: 'component-class-special-prefix-b',
@@ -1025,25 +1025,25 @@ describe('Component', function () {
           styleScope: componentSpace.styleScopeManager.register('b'),
           extraStyleScope: glassEasel.StyleScopeManager.globalScope(),
         },
-        template: '<component-class-special-prefix-a id="b" class="b ^b ^^b ^^^bbb ~bb" />',
+        template: '<component-class-special-prefix-a id="b" class="b ^b1 ^^b2 ^^^b3 ~b4" />',
       })
       regElem({
         is: 'component-class-special-prefix-c',
         options: {
           styleScope: componentSpace.styleScopeManager.register('c'),
         },
-        template: '<component-class-special-prefix-b id="c" class="c ^c ~c" />',
+        template: '<component-class-special-prefix-b id="c" class="c ^c1 ^^c2 ~c3" />',
       })
       var elem = createElem('component-class-special-prefix-c')
-      expect(elem.$.c.class).toBe('c ^c ~c')
-      expect(elem.$.c.$$.getAttribute('class')).toBe('c--c c')
-      expect(elem.$.c.shadowRoot.querySelector('.bb').$$.getAttribute('class')).toBe(
-        'b b--b c--b c--bbb c--bb',
+      expect(elem.$.c.class).toBe('c ^c1 ^^c2 ~c3')
+      expect(elem.$.c.$$.getAttribute('class')).toBe('c--c c--c1 c--c2 c--c3')
+      expect(elem.$.c.shadowRoot.querySelector('.b2').$$.getAttribute('class')).toBe(
+        'b b--b c--b1 c--b2 c--b3 c--b4',
       )
-      expect(elem.$.c.$.b.shadowRoot.querySelector('.aa').$$.getAttribute('class')).toBe(
-        'a--a b--a c--aa c--a',
+      expect(elem.$.c.$.b.shadowRoot.querySelector('.a2').$$.getAttribute('class')).toBe(
+        'a--a b--a1 c--a2 c--a3 c--a4 c--a5',
       )
-      expect(elem.$.c.$.b.$.a.$$.getAttribute('class')).toBe('a--a b--a c--aa c--a')
+      expect(elem.$.c.$.b.$.a.$$.getAttribute('class')).toBe('a--a b--a1 c--a2 c--a3 c--a4 c--a5')
     })
 
     it('should adding write ID and class prefix info to DOM when required', function () {


### PR DESCRIPTION
```js
regElem({
    is: 'comp',
    options: {
        styleScope: componentSpace.styleScopeManager.register('c'),
    },
    template: '<div id="c" class="c ^c1 ^^c2 ~c3" />',
})
var elem = createElem('comp')

expect(elem.$.c.$$.getAttribute('class')).toBe('c--c c--c1 c--c2 c--c3')
// expected 'c--c c--c1 c--c2 c--c3'
// got 'c--c c1 c--c2 c--c3'
```
Fixed the issue above, which got wrong style scope when the numbers of `^` exactly equals the depth in shadow tree.

Also refactored the constructor of `ClassList` for decoupling.
