### PR TITLE
fallback event listener on NativeNode

### DIFF
--- a/glass-easel-template-compiler/src/tree.rs
+++ b/glass-easel-template-compiler/src/tree.rs
@@ -1441,20 +1441,10 @@ impl TmplAttr {
             TmplAttrKind::ModelProperty { name }
             | TmplAttrKind::PropertyOrExternalClass { name } => {
                 let attr_name = gen_lit_str(&name);
-                let method = if name.starts_with("bind")
-                    || name.starts_with("capture-bind")
-                    || name.starts_with("catch")
-                    || name.starts_with("capture-catch")
-                    || name.starts_with("on")
-                {
-                    "R.r"
-                } else {
-                    "O"
-                };
                 match &self.value {
                     TmplAttrValue::Static(v) => {
                         w.expr_stmt(|w| {
-                            write!(w, "if(C){}(N,{},{})", method, attr_name, gen_lit_str(v))?;
+                            write!(w, "if(C)O(N,{},{})", attr_name, gen_lit_str(v))?;
                             Ok(())
                         })?;
                     }
@@ -1466,7 +1456,7 @@ impl TmplAttr {
                         w.expr_stmt(|w| {
                             write!(w, "if(C||K||")?;
                             p.lvalue_state_expr(w, scopes)?;
-                            write!(w, "){}(N,{},", method, attr_name)?;
+                            write!(w, ")O(N,{},", attr_name)?;
                             p.value_expr(w)?;
                             if let TmplAttrKind::ModelProperty { .. } = &self.kind {
                                 write!(w, ",")?;
@@ -1480,7 +1470,7 @@ impl TmplAttr {
                                 binding_map_keys.to_proc_gen_write_map(w, bmc, |w| {
                                     let p = expr.to_proc_gen_prepare(w, scopes)?;
                                     w.expr_stmt(|w| {
-                                        write!(w, "{}(N,{},", method, attr_name)?;
+                                        write!(w, "O(N,{},", attr_name)?;
                                         p.value_expr(w)?;
                                         if let TmplAttrKind::ModelProperty { .. } = &self.kind {
                                             write!(w, ",")?;

--- a/glass-easel/src/tmpl/index.ts
+++ b/glass-easel/src/tmpl/index.ts
@@ -36,7 +36,7 @@ export type ComponentTemplate = {
   groupList?: ProcGenGroupList
   content: (name: string) => ProcGen
   updateMode?: string
-  disallowNativeNode?: boolean
+  fallbackListenerOnNativeNode?: boolean
   eventObjectFilter?: (x: ShadowedEvent<unknown>) => ShadowedEvent<unknown>
   procGenWrapperType?: typeof ProcGenWrapper
 }
@@ -62,7 +62,7 @@ export class GlassEaselTemplateEngine implements templateEngine.TemplateEngine {
 class GlassEaselTemplate implements templateEngine.Template {
   genObjectGroupEnv!: ProcGenEnv
   updateMode!: string
-  disallowNativeNode!: boolean
+  fallbackListenerOnNativeNode!: boolean
   eventObjectFilter?: (x: ShadowedEvent<unknown>) => ShadowedEvent<unknown>
 
   constructor(behavior: GeneralBehavior) {
@@ -89,7 +89,7 @@ class GlassEaselTemplate implements templateEngine.Template {
       group: c.content,
     }
     this.updateMode = c.updateMode || ''
-    this.disallowNativeNode = c.disallowNativeNode || false
+    this.fallbackListenerOnNativeNode = c.fallbackListenerOnNativeNode || false
     this.eventObjectFilter = c.eventObjectFilter
   }
 
@@ -130,7 +130,7 @@ class GlassEaselTemplateInstance implements templateEngine.TemplateInstance {
     this.procGenWrapper = new ProcGenWrapper(
       this.shadowRoot,
       procGen,
-      template.disallowNativeNode,
+      template.fallbackListenerOnNativeNode,
       template.eventObjectFilter,
     )
     this.bindingMapGen = undefined

--- a/glass-easel/tests/base/env.ts
+++ b/glass-easel/tests/base/env.ts
@@ -37,7 +37,7 @@ export const execWithWarn = <T>(expectCount: number, func: () => T): T => {
 
 type TemplateOptions = {
   updateMode?: string
-  disallowNativeNode?: boolean
+  fallbackListenerOnNativeNode?: boolean
 }
 
 export const tmpl = (src: string, options?: TemplateOptions) => {


### PR DESCRIPTION
1. Add `fallbackListenerOnNativeNode`  option to fallback `bindxxx` legacy event binding syntax on native nodes.
2. Remove `disallowNativeNode` option (use `setGlobalUsingComponent` api).
3. Change `ProcGenWrapper#r` to an arrow function for `this` expression compatibility.
4. Remove `R.r` generation in template compiler. **WARNING: This is a forward compatibility hazard**