### PR TITLE
fix(glass-easel-miniprogram-adapter): externalComponent option missing

### DIFF
--- a/glass-easel-miniprogram-adapter/src/space.ts
+++ b/glass-easel-miniprogram-adapter/src/space.ts
@@ -361,6 +361,7 @@ export class CodeSpace {
       dataDeepCopy: options?.dataDeepCopy,
       propertyPassingDeepCopy: options?.propertyPassingDeepCopy,
       propertyEarlyInit: options?.propertyEarlyInit,
+      externalComponent: options?.externalComponent,
     }
     return [ret, styleIsolation]
   }

--- a/glass-easel-miniprogram-adapter/src/types.ts
+++ b/glass-easel-miniprogram-adapter/src/types.ts
@@ -33,6 +33,7 @@ export type ComponentDefinitionOptions = {
   dataDeepCopy?: DeepCopyKind
   propertyPassingDeepCopy?: DeepCopyKind
   propertyEarlyInit?: boolean
+  externalComponent?: boolean
 }
 
 type ComponentMethod = utils.ComponentMethod


### PR DESCRIPTION
## Bug 说明
根据 externalComponent 文档，在组件声明了 externalComponent 属性，发现最终没有传递到 `_$advancedCreate`
```js
Component({
  options: {
    externalComponent: true,
  }
})
```

排查后发现是在 `prepareComponentOptions` 阶段，没有继续传递 externalComponent 属性。