### PR TITLE
feat(template-compiler): shorten generated code

### DIFF
--- a/glass-easel-template-compiler/src/tree.rs
+++ b/glass-easel-template-compiler/src/tree.rs
@@ -276,22 +276,12 @@ impl TmplTree {
                     write!(w, "var I=")?;
                     w.function_args("P", |w| {
                         w.expr_stmt(|w| {
-                            write!(w, "if(!S)")?;
-                            w.brace_block(|w| {
-                                w.expr_stmt(|w| {
-                                    write!(w, "S={{}}")?;
-                                    Ok(())
-                                })?;
-                                w.expr_stmt(|w| {
-                                    write!(w, "Object.assign(S")?;
-                                    for target_path in self.imports.iter() {
-                                        let p = path::resolve(&self.path, target_path);
-                                        write!(w, ",G[{}]._", gen_lit_str(&p))?;
-                                    }
-                                    write!(w, ",H)")?;
-                                    Ok(())
-                                })
-                            })?;
+                            write!(w, "if(!S)S=Object.assign({{}}")?;
+                            for target_path in self.imports.iter() {
+                                let p = path::resolve(&self.path, target_path);
+                                write!(w, ",G[{}]._", gen_lit_str(&p))?;
+                            }
+                            write!(w, ",H)")?;
                             Ok(())
                         })?;
                         w.expr_stmt(|w| {


### PR DESCRIPTION
Shorten generated code introduced in #110 a little bit by changing
```typescript
if (!S) {
  S = {};
  Object.assign(S, G['imports']._, H);
}
```
to
```typescript
if (!S) S = Object.assign({}, G['imports']._, H);
```
