### PR TITLE
Fix wxs scripts with template

### DIFF
--- a/glass-easel-template-compiler/src/tree.rs
+++ b/glass-easel-template-compiler/src/tree.rs
@@ -304,6 +304,7 @@ impl TmplTree {
                             w.paren(|w| {
                                 w.function(|w| {
                                     let mut writer = JsTopScopeWriter::new(String::new());
+                                    writer.align(w);
                                     writer.function_scope(|w| {
                                         w.set_var_on_top_scope("L")?;
                                         w.set_var_on_top_scope("M")?;
@@ -414,7 +415,7 @@ impl TmplTree {
                 let scopes = &mut vec![];
                 let has_scripts = if self.scripts.len() > 0 {
                     for script in &self.scripts {
-                        let ident = w.gen_private_ident();
+                        let ident = w.gen_ident();
                         let lvalue_path = match script {
                             TmplScript::GlobalRef {
                                 module_name: _,

--- a/glass-easel/tests/tmpl/structure.test.ts
+++ b/glass-easel/tests/tmpl/structure.test.ts
@@ -1252,6 +1252,25 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     matchElementWithDom(elem)
   })
 
+  test('custom scripts with template', () => {
+    const def = glassEasel
+      .registerElement({
+        template: tmpl(`
+          <wxs module="a">module.exports={ foo: 'foo' }</wxs>
+          <template name="test">
+            <div>{{a.foo}}</div>
+          </template>
+          <template is="test" data="{{ a: { foo: 'bar' } }}" />
+          <div>{{a.foo}}</div>
+        `),
+        data: {},
+      })
+      .general()
+    const elem = glassEasel.Component.createWithContext('root', def, testBackend).asInstanceOf(def)!
+    expect(domHtml(elem)).toBe('<div>foo</div><div>foo</div>')
+    matchElementWithDom(elem)
+  })
+
   test('block slot', () => {
     const childComp = glassEasel.registerElement({
       options: {


### PR DESCRIPTION
Template compiler will got wrong output when using wxs scripts

```html
// a.wxml
<wxs module="a">module.exports={ foo: 'foo' }</wxs>
<template name="test">
    <div>{{a.foo}}</div>
</template>
<template is="test" />
```