### PR TITLE
chore: workspace packages should be specified in version

### DIFF
--- a/glass-easel-miniprogram-adapter/package.json
+++ b/glass-easel-miniprogram-adapter/package.json
@@ -25,10 +25,10 @@
     "coverage": "jest -c jest.config.js --collect-coverage"
   },
   "peerDependencies": {
-    "glass-easel": "0.4.0"
+    "glass-easel": "workspace:*"
   },
   "devDependencies": {
-    "glass-easel": "0.4.0",
-    "glass-easel-template-compiler": "0.4.0"
+    "glass-easel": "workspace:*",
+    "glass-easel-template-compiler": "workspace:*"
   }
 }

--- a/glass-easel-miniprogram-template/package.json
+++ b/glass-easel-miniprogram-template/package.json
@@ -7,8 +7,8 @@
     "dev": "webpack --config webpack.config.js --watch"
   },
   "dependencies": {
-    "glass-easel": "0.4.0",
-    "glass-easel-miniprogram-adapter": "0.4.0"
+    "glass-easel": "workspace:*",
+    "glass-easel-miniprogram-adapter": "workspace:*"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.6.0",
@@ -17,7 +17,7 @@
     "eslint": "^7.17.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-promise": "^4.2.1",
-    "glass-easel-miniprogram-webpack-plugin": "0.4.0",
+    "glass-easel-miniprogram-webpack-plugin": "workspace:*",
     "less": "^4.1.3",
     "less-loader": "^11.0.0",
     "mini-css-extract-plugin": "^2.6.1",

--- a/glass-easel-miniprogram-webpack-plugin/package.json
+++ b/glass-easel-miniprogram-webpack-plugin/package.json
@@ -21,14 +21,14 @@
     "lint": "eslint src/**/*.ts"
   },
   "peerDependencies": {
-    "glass-easel": "0.4.0",
-    "glass-easel-miniprogram-adapter": "0.4.0",
+    "glass-easel": "workspace:*",
+    "glass-easel-miniprogram-adapter": "workspace:*",
     "webpack": "^5.85.0"
   },
   "dependencies": {
     "chokidar": "^3.5.3",
-    "glass-easel-stylesheet-compiler": "0.4.0",
-    "glass-easel-template-compiler": "0.4.0",
+    "glass-easel-stylesheet-compiler": "workspace:*",
+    "glass-easel-template-compiler": "workspace:*",
     "source-map": "^0.7.4",
     "webpack-sources": "^3.2.1",
     "webpack-virtual-modules": "^0.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,25 +102,25 @@ importers:
   glass-easel:
     devDependencies:
       glass-easel-template-compiler:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-template-compiler
 
   glass-easel-miniprogram-adapter:
     devDependencies:
       glass-easel:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel
       glass-easel-template-compiler:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-template-compiler
 
   glass-easel-miniprogram-template:
     dependencies:
       glass-easel:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel
       glass-easel-miniprogram-adapter:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-miniprogram-adapter
     devDependencies:
       '@typescript-eslint/eslint-plugin':
@@ -142,7 +142,7 @@ importers:
         specifier: ^4.2.1
         version: 4.3.1
       glass-easel-miniprogram-webpack-plugin:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-miniprogram-webpack-plugin
       less:
         specifier: ^4.1.3
@@ -172,16 +172,16 @@ importers:
         specifier: ^3.5.3
         version: 3.5.3
       glass-easel:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel
       glass-easel-miniprogram-adapter:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-miniprogram-adapter
       glass-easel-stylesheet-compiler:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-stylesheet-compiler
       glass-easel-template-compiler:
-        specifier: 0.4.0
+        specifier: workspace:*
         version: link:../glass-easel-template-compiler
       source-map:
         specifier: ^0.7.4


### PR DESCRIPTION
By specifying workspace versions, `pnpm run --recursive` will be able to read package dependencies inside workspace and run `build` script topologically