### PR TITLE
Fix placeholder's dataset inside wx:for

### DIFF
--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -1069,6 +1069,11 @@ export class ProcGenWrapper {
     }
   }
 
+  // update a attribute
+  a(elem: Element, name: string, v: unknown) {
+    elem.updateAttribute(name, v)
+  }
+
   // set a worklet directive value
   wl(elem: Element, name: string, value: unknown) {
     if (isComponent(elem)) {

--- a/glass-easel/src/tmpl/proc_gen_wrapper_dom.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper_dom.ts
@@ -203,6 +203,11 @@ export class ProcGenWrapperDom {
     }
   }
 
+  // update a attribute
+  a(elem: HTMLElement, name: string, v: unknown) {
+    this.r(elem, name, v)
+  }
+
   // add a change property binding
   p() {
     noop()


### PR DESCRIPTION
Fix placeholder's dataset inside wx:for by creating an extra js scope for wx:for (and slot props).

Giving an example template `<child wx:for="{{arr}}" prop="{{item}}" data-index="{{index}}">{{index}}</child>`  Proc-gen generated code will be changed as the following:
```diff
- var i = (C, T) => {
-   C || K || g ? T(Y(e)) : T();
- },
  c = (C, d, e, f, g, h, T, E) => {
+   var i = (C, T) => {
+     C || K || g ? T(Y(e)) : T();
+   };
    E(
      "child",
      {},
      (N, C) => {
        if (C || K || f) O(N, "prop", d);
        if (C || K || g) R.d(N, "index", e);
      },
      i
    );
  },
  a = (C, T, E, B, F) => {
    F(D.arr, null, U ? U.arr : undefined, [0, "arr"], c);
  };
```