### PR TITLE
feat: support extraThisFieldsType(#70)

### DIFF
--- a/glass-easel-miniprogram-adapter/src/behavior.ts
+++ b/glass-easel-miniprogram-adapter/src/behavior.ts
@@ -2,6 +2,7 @@ import type * as glassEasel from 'glass-easel'
 import { type GeneralComponentDefinition, type utils as typeUtils } from './types'
 import { type GeneralComponent } from './component'
 
+type Empty = typeUtils.Empty
 type DataList = typeUtils.DataList
 type PropertyList = typeUtils.PropertyList
 type MethodList = typeUtils.MethodList
@@ -16,6 +17,7 @@ export type GeneralBehavior = Behavior<
   Record<string, any>,
   Record<string, any>,
   Record<string, any>,
+  any,
   any
 >
 
@@ -25,6 +27,7 @@ export class Behavior<
   TMethod extends MethodList,
   TChainingFilter extends ChainingFilterType,
   TComponentExport = never,
+  TExtraThisFields extends DataList = Empty,
 > {
   /** @internal */
   _$: glassEasel.GeneralBehavior
@@ -35,7 +38,7 @@ export class Behavior<
 
   /** @internal */
   constructor(
-    inner: glassEasel.Behavior<TData, TProperty, TMethod, TChainingFilter>,
+    inner: glassEasel.Behavior<TData, TProperty, TMethod, TChainingFilter, TExtraThisFields>,
     parents: GeneralBehavior[],
     definitionFilter: DefinitionFilter | undefined,
     componentExport: ((source: GeneralComponent | null) => TComponentExport) | undefined,

--- a/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
@@ -32,6 +32,7 @@ export class BaseBehaviorBuilder<
   TChainingFilter extends ChainingFilterType = never,
   TPendingChainingFilter extends ChainingFilterType = never,
   TComponentExport = never,
+  TExtraThisFields extends DataList = Empty,
 > {
   protected _$codeSpace!: CodeSpace
   protected _$!: glassEasel.BehaviorBuilder<
@@ -40,7 +41,8 @@ export class BaseBehaviorBuilder<
     TProperty,
     TMethod,
     TChainingFilter,
-    TPendingChainingFilter
+    TPendingChainingFilter,
+    TExtraThisFields
   >
   protected _$parents: GeneralBehavior[] = []
   protected _$export?: (source: GeneralComponent | null) => TComponentExport
@@ -71,7 +73,8 @@ export class BaseBehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -90,7 +93,8 @@ export class BaseBehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -109,7 +113,8 @@ export class BaseBehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -123,7 +128,7 @@ export class BaseBehaviorBuilder<
    * The public method can be used as an event handler, and can be visited in component instance.
    */
   methods<T extends MethodList>(
-    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any>>,
+    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any, TExtraThisFields>>,
   ): ResolveBehaviorBuilder<
     BaseBehaviorBuilder<
       TPrevData,
@@ -132,7 +137,8 @@ export class BaseBehaviorBuilder<
       TMethod & T,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -153,7 +159,7 @@ export class BaseBehaviorBuilder<
     >,
   >(
     paths: P,
-    func: (this: Component<TData, TProperty, TMethod, any>, newValue: V) => void,
+    func: (this: Component<TData, TProperty, TMethod, any, TExtraThisFields>, newValue: V) => void,
     once?: boolean,
   ): ResolveBehaviorBuilder<this, TChainingFilter>
   observer<
@@ -169,14 +175,17 @@ export class BaseBehaviorBuilder<
   >(
     paths: readonly [...P],
     func: (
-      this: Component<TData, TProperty, TMethod, any>,
+      this: Component<TData, TProperty, TMethod, any, TExtraThisFields>,
       ...newValues: V extends any[] ? V : never
     ) => void,
     once?: boolean,
   ): ResolveBehaviorBuilder<this, TChainingFilter>
   observer(
     paths: string | readonly string[],
-    func: (this: Component<TData, TProperty, TMethod, any>, ...args: any[]) => any,
+    func: (
+      this: Component<TData, TProperty, TMethod, any, TExtraThisFields>,
+      ...args: any[]
+    ) => any,
     once = false,
   ): ResolveBehaviorBuilder<this, TChainingFilter> {
     this._$.observer(paths as any, func as any, once)
@@ -189,7 +198,7 @@ export class BaseBehaviorBuilder<
   lifetime<L extends keyof Lifetimes>(
     name: L,
     func: (
-      this: Component<TData, TProperty, TMethod, any>,
+      this: Component<TData, TProperty, TMethod, any, TExtraThisFields>,
       ...args: Parameters<Lifetimes[L]>
     ) => ReturnType<Lifetimes[L]>,
     once = false,
@@ -203,7 +212,10 @@ export class BaseBehaviorBuilder<
    */
   pageLifetime(
     name: string,
-    func: (this: Component<TData, TProperty, TMethod, any>, ...args: any[]) => any,
+    func: (
+      this: Component<TData, TProperty, TMethod, any, TExtraThisFields>,
+      ...args: any[]
+    ) => any,
     once = false,
   ): ResolveBehaviorBuilder<this, TChainingFilter> {
     this._$.pageLifetime(name, func as any, once)
@@ -215,7 +227,8 @@ export class BaseBehaviorBuilder<
    */
   relation(
     name: string,
-    rel: RelationParams & ThisType<Component<TData, TProperty, TMethod, TComponentExport>>,
+    rel: RelationParams &
+      ThisType<Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>>,
   ): ResolveBehaviorBuilder<this, TChainingFilter> {
     const target =
       rel.target instanceof Behavior || rel.target instanceof ComponentType
@@ -234,11 +247,11 @@ export class BaseBehaviorBuilder<
 
   init<TExport extends Record<string, TaggedMethod<(...args: any[]) => any>> | void>(
     func: (
-      this: Component<TData, TProperty, TMethod, TComponentExport>,
+      this: Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>,
       builderContext: BuilderContext<
         TPrevData,
         TProperty,
-        Component<TData, TProperty, TMethod, TComponentExport>
+        Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>
       >,
     ) => TExport,
     // eslint-disable-next-line function-paren-newline
@@ -250,7 +263,8 @@ export class BaseBehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -294,7 +308,13 @@ export class BaseBehaviorBuilder<
         implement(traitBehavior._$, impl)
       }) as BuilderContext<TPrevData, TProperty, TMethod>['implement']
 
-      const methodCaller = this as unknown as Component<TData, TProperty, TMethod, TComponentExport>
+      const methodCaller = this as unknown as Component<
+        TData,
+        TProperty,
+        TMethod,
+        TComponentExport,
+        TExtraThisFields
+      >
 
       return func.call(methodCaller, {
         self: methodCaller,
@@ -331,7 +351,8 @@ export class BaseBehaviorBuilder<
           TData & TNewData,
           TProperty & TNewProperty,
           TMethod & TNewMethod,
-          TNewComponentExport
+          TNewComponentExport,
+          TExtraThisFields
         >
       >,
   ): ResolveBehaviorBuilder<
@@ -342,7 +363,8 @@ export class BaseBehaviorBuilder<
       TMethod & TNewMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {

--- a/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
@@ -30,6 +30,7 @@ export class BehaviorBuilder<
   TChainingFilter extends ChainingFilterType = never,
   TPendingChainingFilter extends ChainingFilterType = never,
   TComponentExport = never,
+  TExtraThisFields extends DataList = Empty,
 > extends BaseBehaviorBuilder<
   TPrevData,
   TData,
@@ -37,7 +38,8 @@ export class BehaviorBuilder<
   TMethod,
   TChainingFilter,
   TPendingChainingFilter,
-  TComponentExport
+  TComponentExport,
+  TExtraThisFields
 > {
   private _$definitionFilter: DefinitionFilter | undefined
 
@@ -66,7 +68,8 @@ export class BehaviorBuilder<
         add: TAddedFields
         remove: TRemovedFields
       },
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -80,8 +83,9 @@ export class BehaviorBuilder<
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UChainingFilter extends ChainingFilterType,
+    UExtraThisFields extends DataList,
   >(
-    behavior: Behavior<UData, UProperty, UMethod, UChainingFilter>,
+    behavior: Behavior<UData, UProperty, UMethod, UChainingFilter, UExtraThisFields>,
   ): ResolveBehaviorBuilder<
     BehaviorBuilder<
       TPrevData,
@@ -90,7 +94,8 @@ export class BehaviorBuilder<
       TMethod & UMethod,
       UChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields & UExtraThisFields
     >,
     UChainingFilter
   > {
@@ -111,7 +116,8 @@ export class BehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -134,7 +140,8 @@ export class BehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -157,7 +164,8 @@ export class BehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -170,7 +178,7 @@ export class BehaviorBuilder<
    * The public method can be used as an event handler, and can be visited in component instance.
    */
   override methods<T extends MethodList>(
-    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any>>,
+    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any, TExtraThisFields>>,
   ): ResolveBehaviorBuilder<
     BehaviorBuilder<
       TPrevData,
@@ -179,7 +187,8 @@ export class BehaviorBuilder<
       TMethod & T,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -195,11 +204,11 @@ export class BehaviorBuilder<
    */
   override init<TExport extends Record<string, TaggedMethod<(...args: any[]) => any>> | void>(
     func: (
-      this: Component<TData, TProperty, TMethod, TComponentExport>,
+      this: Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>,
       builderContext: BuilderContext<
         TPrevData,
         TProperty,
-        Component<TData, TProperty, TMethod, TComponentExport>
+        Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>
       >,
     ) => TExport,
     // eslint-disable-next-line function-paren-newline
@@ -211,7 +220,8 @@ export class BehaviorBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -231,7 +241,8 @@ export class BehaviorBuilder<
           TData & TNewData,
           TProperty & TNewProperty,
           TMethod & TNewMethod,
-          TNewComponentExport
+          TNewComponentExport,
+          TExtraThisFields
         >
       >,
   ): ResolveBehaviorBuilder<
@@ -242,7 +253,8 @@ export class BehaviorBuilder<
       TMethod & TNewMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -254,12 +266,38 @@ export class BehaviorBuilder<
   /**
    * Finish the behavior definition process
    */
-  register(): Behavior<TData, TProperty, TMethod, TPendingChainingFilter, TComponentExport> {
+  register(): Behavior<
+    TData,
+    TProperty,
+    TMethod,
+    TPendingChainingFilter,
+    TComponentExport,
+    TExtraThisFields
+  > {
     return new Behavior(
       this._$.registerBehavior(),
       this._$parents,
       this._$definitionFilter,
       this._$export,
     )
+  }
+
+  /**
+   * Add extra this fields type
+   */
+  extraThisFieldsType<T extends DataList>(): ResolveBehaviorBuilder<
+    BehaviorBuilder<
+      TPrevData,
+      TData,
+      TProperty,
+      TMethod,
+      TChainingFilter,
+      TPendingChainingFilter,
+      TComponentExport,
+      TExtraThisFields & T
+    >,
+    TChainingFilter
+  > {
+    return this as any
   }
 }

--- a/glass-easel-miniprogram-adapter/src/builder/component_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/component_builder.ts
@@ -36,6 +36,7 @@ export class ComponentBuilder<
   TChainingFilter extends ChainingFilterType = never,
   TPendingChainingFilter extends ChainingFilterType = never,
   TComponentExport = never,
+  TExtraThisFields extends DataList = Empty,
 > extends BaseBehaviorBuilder<
   TPrevData,
   TData,
@@ -43,7 +44,8 @@ export class ComponentBuilder<
   TMethod,
   TChainingFilter,
   TPendingChainingFilter,
-  TComponentExport
+  TComponentExport,
+  TExtraThisFields
 > {
   private _$is!: string
   private _$alias?: string[]
@@ -92,8 +94,16 @@ export class ComponentBuilder<
     UMethod extends MethodList,
     UChainingFilter extends ChainingFilterType,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
-    behavior: Behavior<UData, UProperty, UMethod, UChainingFilter, UComponentExport>,
+    behavior: Behavior<
+      UData,
+      UProperty,
+      UMethod,
+      UChainingFilter,
+      UComponentExport,
+      UExtraThisFields
+    >,
   ): ResolveBehaviorBuilder<
     ComponentBuilder<
       TPrevData,
@@ -102,7 +112,8 @@ export class ComponentBuilder<
       TMethod & UMethod,
       UChainingFilter,
       TPendingChainingFilter,
-      UComponentExport
+      UComponentExport,
+      TExtraThisFields & UExtraThisFields
     >,
     UChainingFilter
   > {
@@ -127,7 +138,8 @@ export class ComponentBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -152,7 +164,8 @@ export class ComponentBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -175,7 +188,8 @@ export class ComponentBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -188,7 +202,7 @@ export class ComponentBuilder<
    * The public method can be used as an event handler, and can be visited in component instance.
    */
   override methods<T extends MethodList>(
-    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any>>,
+    funcs: T & ThisType<Component<TData, TProperty, TMethod & T, any, TExtraThisFields>>,
   ): ResolveBehaviorBuilder<
     ComponentBuilder<
       TPrevData,
@@ -197,7 +211,8 @@ export class ComponentBuilder<
       TMethod & T,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -213,11 +228,11 @@ export class ComponentBuilder<
    */
   override init<TExport extends Record<string, TaggedMethod<(...args: any[]) => any>> | void>(
     func: (
-      this: Component<TData, TProperty, TMethod, TComponentExport>,
+      this: Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>,
       builderContext: BuilderContext<
         TPrevData,
         TProperty,
-        Component<TData, TProperty, TMethod, TComponentExport>
+        Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>
       >,
     ) => TExport,
     // eslint-disable-next-line function-paren-newline
@@ -229,7 +244,8 @@ export class ComponentBuilder<
       TMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -249,7 +265,8 @@ export class ComponentBuilder<
           TData & TNewData,
           TProperty & TNewProperty,
           TMethod & TNewMethod,
-          TNewComponentExport
+          TNewComponentExport,
+          TExtraThisFields
         >
       >,
   ): ResolveBehaviorBuilder<
@@ -260,7 +277,8 @@ export class ComponentBuilder<
       TMethod & TNewMethod,
       TChainingFilter,
       TPendingChainingFilter,
-      TNewComponentExport
+      TNewComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -271,7 +289,15 @@ export class ComponentBuilder<
 
   pageDefinition<TNewData extends DataList, TNewExtraFields extends { [k: PropertyKey]: any }>(
     def: PageDefinition<TNewData, TNewExtraFields> &
-      ThisType<Component<TData & TNewData, TProperty, TMethod & TNewExtraFields, undefined>>,
+      ThisType<
+        Component<
+          TData & TNewData,
+          TProperty,
+          TMethod & TNewExtraFields,
+          undefined,
+          TExtraThisFields
+        >
+      >,
   ): ResolveBehaviorBuilder<
     ComponentBuilder<
       TPrevData,
@@ -280,7 +306,8 @@ export class ComponentBuilder<
       TMethod & TNewExtraFields,
       TChainingFilter,
       TPendingChainingFilter,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >,
     TChainingFilter
   > {
@@ -333,5 +360,24 @@ export class ComponentBuilder<
       this._$codeSpace.getComponentSpace().exportComponent(alias, this._$is)
     })
     return new ComponentType(compDef)
+  }
+
+  /**
+   * Add extra this fields type
+   */
+  extraThisFieldsType<T extends DataList>(): ResolveBehaviorBuilder<
+    ComponentBuilder<
+      TPrevData,
+      TData,
+      TProperty,
+      TMethod,
+      TChainingFilter,
+      TPendingChainingFilter,
+      TComponentExport,
+      TExtraThisFields & T
+    >,
+    TChainingFilter
+  > {
+    return this as any
   }
 }

--- a/glass-easel-miniprogram-adapter/src/component.ts
+++ b/glass-easel-miniprogram-adapter/src/component.ts
@@ -5,6 +5,7 @@ import { SelectorQuery } from './selector_query'
 import { IntersectionObserver } from './intersection'
 import { MediaQueryObserver } from './media_query'
 
+type Empty = typeUtils.Empty
 type DataList = typeUtils.DataList
 type PropertyList = typeUtils.PropertyList
 type MethodList = typeUtils.MethodList
@@ -76,9 +77,10 @@ export type Component<
   TProperty extends PropertyList,
   TMethod extends MethodList,
   TComponentExport,
+  TExtraThisFields extends DataList = Empty,
 > = ComponentCaller<TData, TProperty, TMethod, TComponentExport> & {
   [k in keyof TMethod]: TMethod[k]
-}
+} & TExtraThisFields
 
 export class ComponentCaller<
   TData extends DataList,

--- a/glass-easel-miniprogram-adapter/tests/space.test.ts
+++ b/glass-easel-miniprogram-adapter/tests/space.test.ts
@@ -1069,4 +1069,43 @@ describe('define', () => {
     glassEasel.Element.pretendAttached(root.getComponent())
     expect(domHtml(root.getComponent())).toBe('<list><div>2</div><item></item><item></item></list>')
   })
+
+  test('chaining extraThisFieldsType', () => {
+    const env = new MiniProgramEnv()
+    const codeSpace = env.createCodeSpace('', true)
+
+    codeSpace.addCompiledTemplate(
+      'path/to/comp',
+      tmpl(`
+      <div>{{hello}}</div>
+    `),
+    )
+
+    const beh = codeSpace
+      .behavior()
+      .extraThisFieldsType<{ behDelayedData: string }>()
+      .lifetime('created', function () {
+        this.behDelayedData = ' World!'
+      })
+      .register()
+
+    codeSpace
+      .component('path/to/comp')
+      .behavior(beh)
+      .extraThisFieldsType<{ delayedData: string }>()
+      .data(() => ({
+        hello: '',
+      }))
+      .lifetime('created', function () {
+        this.delayedData = 'Hello'
+        this.setData({
+          hello: this.delayedData + this.behDelayedData,
+        })
+      })
+      .register()
+
+    const ab = env.associateBackend()
+    const root = ab.createRoot('body', codeSpace, 'path/to/comp')
+    expect(domHtml(root.getComponent())).toBe('<div>Hello World!</div>')
+  })
 })

--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -241,7 +241,7 @@ export class ComponentDefinition<
   TMethod extends MethodList,
 > {
   is: string
-  behavior: Behavior<TData, TProperty, TMethod, any>
+  behavior: Behavior<TData, TProperty, TMethod, any, any>
   /** @internal */
   _$detail: ComponentDefinitionDetail<TData, TProperty, TMethod> | null
   /** @internal */
@@ -250,7 +250,7 @@ export class ComponentDefinition<
   private _$templateEngine: TemplateEngine
 
   /** @internal */
-  constructor(behavior: Behavior<TData, TProperty, TMethod, any>) {
+  constructor(behavior: Behavior<TData, TProperty, TMethod, any, any>) {
     this.behavior = behavior
     this.is = this.behavior.is
     this._$detail = null
@@ -421,7 +421,7 @@ export class Component<
 > extends Element {
   [COMPONENT_SYMBOL]: true
   /** @internal */
-  _$behavior: Behavior<TData, TProperty, TMethod, any>
+  _$behavior: Behavior<TData, TProperty, TMethod, any, any>
   /** @internal */
   _$definition: ComponentDefinition<TData, TProperty, TMethod>
   /** @internal */
@@ -697,7 +697,11 @@ export class Component<
 
     // call method caller init
     if (behavior._$methodCallerInit) {
-      const methodCaller = behavior._$methodCallerInit.call(comp)
+      const methodCaller = behavior._$methodCallerInit.call(comp) as unknown as ComponentInstance<
+        TData,
+        TProperty,
+        TMethod
+      >
       comp._$methodCaller = methodCaller
     }
 

--- a/glass-easel/src/component_params.ts
+++ b/glass-easel/src/component_params.ts
@@ -399,10 +399,12 @@ export type ComponentInstance<
   TData extends DataList,
   TProperty extends PropertyList,
   TMethod extends MethodList,
+  TExtraThisFields extends DataList = Empty,
 > = Component<TData, TProperty, TMethod> & {
   data: Merge<DataWithPropertyValues<TData, TProperty>>
   properties: Merge<DataWithPropertyValues<TData, TProperty>>
-} & TMethod
+} & TMethod &
+  TExtraThisFields
 
 export type ComponentParams<
   TData extends DataList,

--- a/glass-easel/src/component_space.ts
+++ b/glass-easel/src/component_space.ts
@@ -379,7 +379,9 @@ export class ComponentSpace {
    *
    * This API is generally designed for adapters which require special method callers.
    */
-  defineWithMethodCaller(is?: string): BehaviorBuilder<Empty, Empty, Empty, Empty, never, never> {
+  defineWithMethodCaller(
+    is?: string,
+  ): BehaviorBuilder<Empty, Empty, Empty, Empty, never, never, Empty> {
     return new BehaviorBuilder(is, this)
   }
 

--- a/glass-easel/tests/core/behavior.test.ts
+++ b/glass-easel/tests/core/behavior.test.ts
@@ -612,4 +612,37 @@ describe('chaining-form interface', () => {
     const elem = glassEasel.Component.createWithContext('root', compDef, domBackend)
     expect(domHtml(elem)).toBe('<div>123</div>')
   })
+
+  test('chaining extraThisFieldsType', () => {
+    const beh = componentSpace
+      .define()
+      .extraThisFieldsType<{ behDelayedData: string }>()
+      .lifetime('created', function () {
+        this.behDelayedData = ' World!'
+      })
+      .registerBehavior()
+
+    const compDef = componentSpace
+      .define()
+      .behavior(beh)
+      .extraThisFieldsType<{ delayedData: string }>()
+      .data(() => ({
+        hello: '',
+      }))
+      .lifetime('created', function () {
+        this.delayedData = 'Hello'
+        this.setData({
+          hello: this.delayedData + this.behDelayedData,
+        })
+      })
+      .template(
+        tmpl(`
+        <div>{{hello}}</div>
+      `),
+      )
+      .registerComponent()
+
+    const elem = glassEasel.Component.createWithContext('root', compDef, domBackend)
+    expect(domHtml(elem)).toBe('<div>Hello World!</div>')
+  })
 })


### PR DESCRIPTION
Add extraThisFieldsType to enhance type completeness of ComponentInstance, which makes custom properties and methods type safe on "this"
- chaining api only
- on legacy framework need a polyfill which could convert chaining api to mini-program-like api