### PR TITLE
Allow template-compiler js-bindings to obtain template parse error level

### DIFF
--- a/glass-easel-template-compiler/src/js_bindings.rs
+++ b/glass-easel-template-compiler/src/js_bindings.rs
@@ -10,8 +10,10 @@ use self::parse::{ParseError, ParseErrorLevel};
 use super::*;
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TemplateParseError {
     is_error: bool,
+    level: ParseErrorLevel,
     code: u32,
     message: String,
     path: String,
@@ -25,6 +27,7 @@ impl From<ParseError> for TemplateParseError {
     fn from(value: ParseError) -> Self {
         Self {
             is_error: value.kind.level() >= ParseErrorLevel::Error,
+            level: value.kind.level(),
             code: value.code() as u32,
             message: value.kind.to_string(),
             path: value.path.to_string(),

--- a/glass-easel-template-compiler/src/parse/mod.rs
+++ b/glass-easel-template-compiler/src/parse/mod.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use super::binding_map;
+use serde::{Deserialize, Serialize};
 pub use tag::Template;
 
 #[cfg(test)]
@@ -534,7 +535,7 @@ impl std::fmt::Display for ParseErrorKind {
 }
 
 #[repr(u8)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum ParseErrorLevel {
     /// Likely to be an mistake and should be noticed.
     ///


### PR DESCRIPTION
JavaScript version for #145

Also change `TemplateParseError` to camelCase to better fit in JavaScript