### PR TITLE
Refactor property value and default function resolution

### DIFF
--- a/glass-easel/src/behavior.ts
+++ b/glass-easel/src/behavior.ts
@@ -42,6 +42,7 @@ import { parseMultiPaths, type MultiPaths } from './data_path'
 import {
   DataGroupObserverTree,
   NormalizedPropertyType,
+  getPropertyFallbackValue,
   normalizePropertyType,
   normalizePropertyTypeShortHand,
   shallowMerge,
@@ -1192,8 +1193,10 @@ export class Behavior<
         const { name, def } = properties[i]!
         const shortHandDef = normalizePropertyTypeShortHand(def)
         let d: PropertyDefinition
+        let initialValueFn: () => DataValue
         if (shortHandDef !== null) {
           d = shortHandDef
+          initialValueFn = shortHandDef.defaultFn
         } else {
           const propDef = def as PropertyOption<any, unknown>
           let type = normalizePropertyType(propDef.type)
@@ -1209,18 +1212,32 @@ export class Behavior<
           if (type === NormalizedPropertyType.Invalid) {
             dispatchError(new Error(`the type of property "${name}" is illegal`), `[prepare]`, is)
           }
-          let value: DataValue = propDef.value
-          if (propDef.value === undefined) {
-            if (type === NormalizedPropertyType.String) value = ''
-            else if (type === NormalizedPropertyType.Number) value = 0
-            else if (type === NormalizedPropertyType.Boolean) value = false
-            else if (type === NormalizedPropertyType.Array) value = []
-            else value = null
-          } else if (propDef.default !== undefined) {
+          const fallbackValue = getPropertyFallbackValue(type)
+          if (typeof propDef.default === 'function' && propDef.value !== undefined) {
             triggerWarning(
               `the initial value of property "${name}" is not used when its default is provided.`,
               is,
             )
+          }
+          const defaultFn =
+            typeof propDef.default === 'function'
+              ? () => {
+                  const value = safeCallback(
+                    `Property "${name}" Default`,
+                    propDef.default!,
+                    null,
+                    [],
+                    is,
+                  )
+                  return value !== undefined ? value : fallbackValue
+                }
+              : () => fallbackValue
+          if (typeof propDef.default === 'function') {
+            initialValueFn = defaultFn
+          } else if (propDef.value !== undefined) {
+            initialValueFn = () => simpleDeepCopy(propDef.value)
+          } else {
+            initialValueFn = () => fallbackValue
           }
           let observer: ((newValue: any, oldValue: any) => void) | null
           if (typeof propDef.observer === 'function') {
@@ -1265,8 +1282,7 @@ export class Behavior<
           d = {
             type,
             optionalTypes,
-            value,
-            default: propDef.default,
+            defaultFn,
             observer,
             comparer,
             reflectIdPrefix,
@@ -1275,13 +1291,7 @@ export class Behavior<
         this._$propertyMap[name] = d
         initValueFuncs.push({
           name,
-          func:
-            typeof d.default === 'function'
-              ? () => {
-                  const value = safeCallback(`Property "${name}" Default`, d.default!, null, [], is)
-                  return value !== undefined ? value : simpleDeepCopy(d.value)
-                }
-              : () => simpleDeepCopy(d.value),
+          func: initialValueFn,
         })
       }
       this._$data.push(() => {

--- a/glass-easel/src/behavior.ts
+++ b/glass-easel/src/behavior.ts
@@ -1275,7 +1275,7 @@ export class Behavior<
         this._$propertyMap[name] = d
         initValueFuncs.push({
           name,
-          func: d.default === undefined ? () => simpleDeepCopy(d.value) : d.default,
+          func: typeof d.default !== 'function' ? () => simpleDeepCopy(d.value) : d.default,
         })
       }
       this._$data.push(() => {

--- a/glass-easel/src/behavior.ts
+++ b/glass-easel/src/behavior.ts
@@ -1275,13 +1275,13 @@ export class Behavior<
         this._$propertyMap[name] = d
         initValueFuncs.push({
           name,
-          func: () => {
-            if (typeof d.default === 'function') {
-              const value = safeCallback(`Property "${name}" Default`, d.default, null, [], is)
-              if (value !== undefined) return value
-            }
-            return simpleDeepCopy(d.value)
-          },
+          func:
+            typeof d.default === 'function'
+              ? () => {
+                  const value = safeCallback(`Property "${name}" Default`, d.default!, null, [], is)
+                  return value !== undefined ? value : simpleDeepCopy(d.value)
+                }
+              : () => simpleDeepCopy(d.value),
         })
       }
       this._$data.push(() => {

--- a/glass-easel/src/behavior.ts
+++ b/glass-easel/src/behavior.ts
@@ -1229,15 +1229,15 @@ export class Behavior<
                     [],
                     is,
                   )
-                  return value !== undefined ? value : fallbackValue
+                  return value !== undefined ? value : simpleDeepCopy(fallbackValue)
                 }
-              : () => fallbackValue
+              : () => simpleDeepCopy(fallbackValue)
           if (typeof propDef.default === 'function') {
             initialValueFn = defaultFn
           } else if (propDef.value !== undefined) {
             initialValueFn = () => simpleDeepCopy(propDef.value)
           } else {
-            initialValueFn = () => fallbackValue
+            initialValueFn = () => simpleDeepCopy(fallbackValue)
           }
           let observer: ((newValue: any, oldValue: any) => void) | null
           if (typeof propDef.observer === 'function') {


### PR DESCRIPTION
Changes:
1. `property.value` will only be used for determining the initial value of a property
2. ensure that initial data and property values will never be `undefined` when calling `property.default` throws an error

Breaking change: when determining initial value of a property, if `property.default` throws an error, `property.value` will be used in current implementation; now a fallback value will be used, which means `property.value` will be completely ignored when `property.default` is a function.