### PR TITLE
feat: add apis for wxml inspector

### DIFF
--- a/glass-easel/src/class_list.ts
+++ b/glass-easel/src/class_list.ts
@@ -166,8 +166,12 @@ export class ClassList {
   }
 
   /** @internal */
-  _$getAlias(): string[] | undefined {
-    return this._$externalNames
+  _$getAlias(): Record<string, string[] | undefined> {
+    const result = Object.create(null) as Record<string, string[] | undefined>
+    this._$externalNames?.forEach((externalName, index) => {
+      result[externalName] = this._$externalRawAlias![index]
+    })
+    return result
   }
 
   /** @internal */

--- a/glass-easel/src/data_proxy.ts
+++ b/glass-easel/src/data_proxy.ts
@@ -501,6 +501,7 @@ export class DataGroup<
   private _$propertyPassingDeepCopy: DeepCopyStrategy
   private _$reflectToAttributes: boolean
   private _$propFields: { [name: string]: PropertyDefinition }
+  private _$propChanged: Record<string, true> = {}
   /** @internal */
   _$observerTree: DataGroupObserverTree
   private _$observerStatus: boolean[]
@@ -606,6 +607,27 @@ export class DataGroup<
   }
 
   /**
+   * Check if a property exists with the given name
+   */
+  hasProperty(propName: string): boolean {
+    return this._$propFields[propName] !== undefined
+  }
+
+  /**
+   * List all property names
+   */
+  listProperties(): string[] {
+    return Object.keys(this._$propFields)
+  }
+
+  /**
+   * List all changed property names
+   */
+  listChangedProperties(): string[] {
+    return Object.keys(this._$propFields).filter((name) => this._$propChanged[name])
+  }
+
+  /**
    * Add a new property change to queue
    *
    * (Generally designed for template engines.)
@@ -615,8 +637,8 @@ export class DataGroup<
    */
   replaceProperty(propName: string, newData: DataValue): boolean {
     let data = newData
-    const prop = this._$propFields[propName]
-    if (!prop) return false
+    if (!this.hasProperty(propName)) return false
+    this._$propChanged[propName] = true
     if (this._$propertyPassingDeepCopy !== DeepCopyStrategy.None) {
       if (this._$propertyPassingDeepCopy === DeepCopyStrategy.SimpleWithRecursion) {
         data = deepCopy(newData, true)

--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -2432,6 +2432,14 @@ export class Element implements NodeCast {
       ;(this._$backendElement as backend.Element).setDataset(name, value)
       if (ENV.DEV) performanceMeasureEnd()
     }
+
+    if (this._$mutationObserverTarget) {
+      MutationObserverTarget.callAttrObservers(this, {
+        type: 'properties',
+        target: this,
+        attributeName: `data-${name}`,
+      })
+    }
   }
 
   /** Set a mark on the element */

--- a/glass-easel/src/node.ts
+++ b/glass-easel/src/node.ts
@@ -69,12 +69,25 @@ const dumpAttributesToString = (elem: Element): string => {
     if (nodeClass) ret += ` class="${nodeClass}"`
     const style = elem.style
     if (style) ret += ` style="${elem.style}"`
+    const dataset = elem.dataset
+    if (dataset) {
+      Object.keys(dataset).forEach((name) => {
+        ret += ` data-${name}="${String(dataset[name])}"`
+      })
+    }
   }
   if (isVirtualNode(elem)) {
     // empty
   } else if (isComponent(elem)) {
-    Object.keys(elem._$behavior._$propertyMap).forEach((propName) => {
+    elem._$dataGroup.listProperties().forEach((propName) => {
       ret += ` ${propName}="${String((elem.data as DataList)[propName])}"`
+    })
+    const externalClasses = elem.getExternalClasses()
+    Object.keys(externalClasses).forEach((externalClassName) => {
+      const alias = externalClasses[externalClassName]
+      if (alias) {
+        ret += ` ${externalClassName}="${alias.join(' ')}"`
+      }
     })
   } else {
     elem.attributes.forEach((attr) => {

--- a/glass-easel/tests/core/data_proxy.test.ts
+++ b/glass-easel/tests/core/data_proxy.test.ts
@@ -1,4 +1,4 @@
-import { domBackend } from '../base/env'
+import { domBackend, tmpl } from '../base/env'
 import * as glassEasel from '../../src'
 
 const componentSpace = new glassEasel.ComponentSpace()
@@ -51,5 +51,34 @@ describe('dynamic add observer', () => {
     })
     expect(actionOrder).toStrictEqual([1])
     actionOrder = []
+  })
+})
+
+describe('listProperties', () => {
+  it('should list properties', () => {
+    const Comp = componentSpace.defineComponent({
+      properties: {
+        a: String,
+        b: String,
+        c: String,
+      },
+    })
+
+    const Root = componentSpace.defineComponent({
+      using: { comp: Comp },
+      template: tmpl(`<comp id="comp" a="a" />`),
+    })
+
+    const root = glassEasel.Component.createWithContext('root', Root, domBackend).general()
+    const comp = (root.$.comp as glassEasel.GeneralComponent).asInstanceOf(Comp)!
+
+    expect(glassEasel.Component.listProperties(comp)).toStrictEqual(['a', 'b', 'c'])
+    expect(glassEasel.Component.listChangedProperties(comp)).toStrictEqual(['a'])
+
+    comp.setData({ b: 'b' })
+    expect(glassEasel.Component.listChangedProperties(comp)).toStrictEqual(['a'])
+
+    comp._$dataGroup.replaceProperty('c', 'c')
+    expect(glassEasel.Component.listChangedProperties(comp)).toStrictEqual(['a', 'c'])
   })
 })

--- a/glass-easel/tests/core/misc.test.ts
+++ b/glass-easel/tests/core/misc.test.ts
@@ -60,6 +60,38 @@ describe('dump element', () => {
     )
   })
 
+  test('dump node structure (component)', () => {
+    const compDefA = componentSpace.defineComponent({
+      is: 'comp-a',
+      properties: {
+        prop: String,
+      },
+      externalClasses: ['my-class'],
+      template: tmpl('<div class="my-class" />'),
+    })
+    componentSpace.setGlobalUsingComponent('comp-a', compDefA.general())
+    const compDef = componentSpace.defineComponent({
+      is: 'comp-b',
+      template: tmpl(
+        '<comp-a prop="p" data-p="p"></comp-a><comp-a prop="pp" my-class="clz"></comp-a>',
+      ),
+    })
+    const elem = glassEasel.Component.createWithContext('root', compDef.general(), domBackend)
+    const composedDump = glassEasel.dumpElementToString(elem, true)
+    expect(composedDump).toBe(
+      [
+        '<root:comp-b>',
+        '  <(virtual):shadow>',
+        '    <comp-a:comp-a data-p="p" prop="p">',
+        '      <(virtual):shadow>',
+        '        <div class="my-class">',
+        '    <comp-a:comp-a prop="pp" my-class="clz">',
+        '      <(virtual):shadow>',
+        '        <div class="my-class">',
+      ].join('\n'),
+    )
+  })
+
   test('dump node structure (external component)', () => {
     const def = componentSpace.defineComponent({
       options: { externalComponent: true },


### PR DESCRIPTION
1. Added `Component.listChangedProperties` to list properties changed by wxml.
1. Changed `Component.prototype.getExternalClasses` to return the mapping of external classes.
1. Trigger MutationObserver when external classes or dataset changed.
1. Dump external classes and dataset when dump elements.