### PR TITLE
feat(core): expose dispatchError

### DIFF
--- a/glass-easel/src/index.ts
+++ b/glass-easel/src/index.ts
@@ -78,6 +78,7 @@ export * as template from './tmpl'
 export { TraitBehavior } from './trait_behaviors'
 export { VirtualNode } from './virtual_node'
 export {
+  dispatchError,
   addGlobalErrorListener,
   addGlobalWarningListener,
   removeGlobalErrorListener,


### PR DESCRIPTION
Expose `dispatchError` for adapter to wrap codes easier, since this can now be done by an ugly `safeCallback(() => { throw new Error('message') })`.