### PR TITLE
Expand effective range of changePropListener

### DIFF
--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -957,13 +957,13 @@ export class ProcGenWrapper {
 
   // set slot
   // (not used any more, leaving for compatibilities)
-  s(elem: Element, v: string) {
+  s = (elem: Element, v: string) => {
     elem.slot = v
     this.tryCallPropertyChangeListener(elem, 'slot', v)
   }
 
   // set slot value
-  l(elem: Element, name: string, value: unknown, generalLvaluePath?: DataPath | null) {
+  l = (elem: Element, name: string, value: unknown, generalLvaluePath?: DataPath | null) => {
     if (this.shadowRoot.getSlotMode() === SlotMode.Dynamic) {
       this.shadowRoot.replaceSlotValue(elem, name, value)
     } else {
@@ -980,13 +980,13 @@ export class ProcGenWrapper {
   }
 
   // set id
-  i(elem: Element, v: string) {
+  i = (elem: Element, v: string) => {
     elem.id = v
     this.tryCallPropertyChangeListener(elem, 'id', v)
   }
 
   // set class or external classes named `class`
-  c(elem: Element, v: string | string[]) {
+  c = (elem: Element, v: string | string[]) => {
     if (isComponent(elem)) {
       // "class" itself can also be an external class
       const hasExternalClass = elem.hasExternalClass('class')
@@ -999,7 +999,7 @@ export class ProcGenWrapper {
   }
 
   // set style or property named `style`
-  y(elem: Element, v: string) {
+  y = (elem: Element, v: string) => {
     if (isComponent(elem) && Component.hasProperty(elem, 'style')) {
       const nodeDataProxy = Component.getDataProxy(elem)
       const camelName = dashToCamelCase('style')
@@ -1011,17 +1011,17 @@ export class ProcGenWrapper {
   }
 
   // set dataset
-  d(elem: Element, name: string, v: unknown) {
+  d = (elem: Element, name: string, v: unknown) => {
     elem.setDataset(name, v)
   }
 
   // set mark
-  m(elem: Element, name: string, v: unknown) {
+  m = (elem: Element, name: string, v: unknown) => {
     elem.setMark(name, v)
   }
 
   // set event handler
-  v(
+  v = (
     elem: Element,
     evName: string,
     v: unknown,
@@ -1030,7 +1030,7 @@ export class ProcGenWrapper {
     capture: boolean,
     isDynamic: boolean,
     generalLvaluePath?: DataPath | null,
-  ) {
+  ) => {
     const handler = typeof v === 'function' ? v : dataValueToString(v)
     const listener: EventListener<unknown> = (ev) => {
       const host = elem.ownerShadowRoot!.getHostNode()
@@ -1127,13 +1127,13 @@ export class ProcGenWrapper {
   }
 
   // update a attribute
-  a(elem: Element, name: string, v: unknown) {
+  a = (elem: Element, name: string, v: unknown) => {
     elem.updateAttribute(name, v)
     this.tryCallPropertyChangeListener(elem, name, v)
   }
 
   // set a worklet directive value
-  wl(elem: Element, name: string, value: unknown) {
+  wl = (elem: Element, name: string, value: unknown) => {
     if (isComponent(elem)) {
       elem.triggerWorkletChangeLifetime(name, value)
     } else {
@@ -1142,12 +1142,12 @@ export class ProcGenWrapper {
   }
 
   // add a change property binding
-  p(
+  p = (
     elem: Element,
     name: string,
     v: ChangePropListener<unknown>,
     generalLvaluePath?: DataPath | null,
-  ) {
+  ) => {
     const tmplArgs = getTmplArgs(elem)
     if (!tmplArgs.changeProp) {
       tmplArgs.changeProp = Object.create(null) as typeof tmplArgs.changeProp

--- a/glass-easel/tests/tmpl/event.test.ts
+++ b/glass-easel/tests/tmpl/event.test.ts
@@ -315,7 +315,7 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
         <wxs module="modA">
           exports.fA = function (newVal, oldVal, self, target) {
             self._test = 789
-            target._test = newVal + ':' + oldVal
+            target._test = newVal + ':' + (oldVal || '-')
           }
         </wxs>
         <abc id="a" change:abc="{{ modA.fA }}" abc="{{ abc }}" />
@@ -327,7 +327,7 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     const elem = glassEasel.Component.createWithContext('root', def.general(), testBackend)
     const a = elem.getShadowRoot()!.getElementById('a')!
     expect((elem as unknown as { _test: number })._test).toBe(789)
-    expect((a as unknown as { _test: string })._test).toBe('123:')
+    expect((a as unknown as { _test: string })._test).toBe('123:-')
     elem.setData({ abc: 456 })
     expect((a as unknown as { _test: string })._test).toBe('456:123')
   })


### PR DESCRIPTION
1. let property change listener takes effect on all "property-like" attributes, like `class`, `style`, `id`, `slot` or non-property attributes on NativeNode
2. call property change listener with `this` set to `null`, and related component set to owner host
3. initialize a property change listener with `undefined` as first old value
4. change methods for procGen in `ProcGenWrapper` to arrow function, to avoid `this` missing in template calls