### PR TITLE
fix(core): remove placeholderHandler for native node

### DIFF
--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -577,9 +577,9 @@ export class Element implements NodeCast {
           node.triggerLifetime('beforeDetach', [])
         }
         node.childNodes.forEach(callFunc)
+        const f = node._$placeholderHandlerRemover
+        if (typeof f === 'function') f()
         if (isComponent(node)) {
-          const f = node._$placeholderHandlerRemover
-          if (f) f()
           const shadowRoot = node.getShadowRoot()
           if (shadowRoot) callFunc(shadowRoot)
           node._$attached = false


### PR DESCRIPTION
Introduced by #49 

Placeholder handlers for NativeNode are not properly removed when adding support for NativeNode as placeholder.