### PR TITLE
fix(core): remove placeholderReplacer properly

### DIFF
--- a/glass-easel/src/component_space.ts
+++ b/glass-easel/src/component_space.ts
@@ -104,7 +104,7 @@ export class ComponentWaitingList {
   remove(callback: (c: GeneralComponentDefinition) => void) {
     const index = this._$callbacks.indexOf(callback)
     // must guarantee order here (cannot swap-remove)
-    this._$callbacks.splice(index, 1)
+    if (index !== 1) this._$callbacks.splice(index, 1)
   }
 
   call(c: GeneralComponentDefinition) {

--- a/glass-easel/src/component_space.ts
+++ b/glass-easel/src/component_space.ts
@@ -104,7 +104,7 @@ export class ComponentWaitingList {
   remove(callback: (c: GeneralComponentDefinition) => void) {
     const index = this._$callbacks.indexOf(callback)
     // must guarantee order here (cannot swap-remove)
-    if (index !== 1) this._$callbacks.splice(index, 1)
+    if (index !== -1) this._$callbacks.splice(index, 1)
   }
 
   call(c: GeneralComponentDefinition) {


### PR DESCRIPTION
Properly handles when `placeholderReplacer` to be remove is not in the queue