### PR TITLE
fix(core): ensure numeric for-value to be valid array length

### DIFF
--- a/glass-easel/src/tmpl/range_list_diff.ts
+++ b/glass-easel/src/tmpl/range_list_diff.ts
@@ -71,9 +71,11 @@ export class RangeListManager {
         this.ownerShadowRoot.getHostNode(),
         this.elem,
       )
-      items = new Array<string>(dataList)
+      const length =
+        Number.isSafeInteger(dataList) && dataList >= 0 && dataList < 2 ** 32 ? dataList : 0
+      items = new Array<string>(length)
       indexes = null
-      for (let i = 0; i < dataList; i += 1) {
+      for (let i = 0; i < length; i += 1) {
         items[i] = i
       }
     } else {


### PR DESCRIPTION
This fixes error caused by passing `NaN` to `wx:for`, since `arrayLength` should be an integer between 0 and 2<sup>32</sup> - 1 (inclusive)