### PR TITLE
Fix: several issues due to generic typing

### DIFF
--- a/glass-easel-miniprogram-adapter/src/behavior.ts
+++ b/glass-easel-miniprogram-adapter/src/behavior.ts
@@ -1,6 +1,6 @@
 import type * as glassEasel from 'glass-easel'
 import { type GeneralComponentDefinition, type utils as typeUtils } from './types'
-import { type GeneralComponent } from './component'
+import { determineComponentExports, type GeneralComponent } from './component'
 
 type DataList = typeUtils.DataList
 type PropertyList = typeUtils.PropertyList
@@ -48,7 +48,7 @@ export class Behavior<
   ) {
     this._$ = inner as glassEasel.GeneralBehavior
     this._$chainingFilter = chainingFilter
-    this._$export = componentExport
+    this._$export = determineComponentExports(parents, componentExport)
 
     // processing definition filter
     if (definitionFilter !== undefined) {

--- a/glass-easel-miniprogram-adapter/src/behavior.ts
+++ b/glass-easel-miniprogram-adapter/src/behavior.ts
@@ -2,7 +2,6 @@ import type * as glassEasel from 'glass-easel'
 import { type GeneralComponentDefinition, type utils as typeUtils } from './types'
 import { type GeneralComponent } from './component'
 
-type Empty = typeUtils.Empty
 type DataList = typeUtils.DataList
 type PropertyList = typeUtils.PropertyList
 type MethodList = typeUtils.MethodList
@@ -14,10 +13,12 @@ export type DefinitionFilter = (
 ) => void
 
 export type GeneralBehavior = Behavior<
-  Record<string, any>,
-  Record<string, any>,
-  Record<string, any>,
-  any
+  /* TData */ Record<string, any>,
+  /* TProperty */ Record<string, any>,
+  /* TMethod */ Record<string, any>,
+  /* TChainingFilter */ any,
+  /* TComponentExport */ any,
+  /* TExtraThisFields */ Record<string, any>
 >
 
 export class Behavior<
@@ -25,8 +26,8 @@ export class Behavior<
   TProperty extends PropertyList,
   TMethod extends MethodList,
   TChainingFilter extends ChainingFilterType,
-  TComponentExport = never,
-  TExtraThisFields extends DataList = Empty,
+  TComponentExport,
+  TExtraThisFields extends DataList,
 > {
   /** @internal */
   _$: glassEasel.GeneralBehavior
@@ -65,6 +66,8 @@ export class ComponentType<
   TMethod extends MethodList,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TComponentExport,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  TExtraThisFields extends DataList,
 > {
   /** @internal */
   _$: glassEasel.ComponentDefinition<TData, TProperty, TMethod>
@@ -74,6 +77,14 @@ export class ComponentType<
     this._$ = inner
   }
 }
+
+export type GeneralComponentType = ComponentType<
+  /* TData */ Record<string, any>,
+  /* TProperty */ Record<string, any>,
+  /* TMethod */ Record<string, any>,
+  /* TComponentExport */ any,
+  /* TExtraThisFields */ Record<string, any>
+>
 
 export class TraitBehavior<
   TIn extends { [key: string]: any },

--- a/glass-easel-miniprogram-adapter/src/behavior.ts
+++ b/glass-easel-miniprogram-adapter/src/behavior.ts
@@ -33,7 +33,7 @@ export class Behavior<
   /** @internal */
   _$chainingFilter?: typeUtils.ChainingFilterFunc<any, any>
   /** @internal */
-  _$bindedDefinitionFilter?: (target: GeneralComponentDefinition) => void
+  _$boundDefinitionFilter?: (target: GeneralComponentDefinition) => void
   /** @internal */
   _$export?: (source: GeneralComponent | null) => TComponentExport
 
@@ -51,8 +51,8 @@ export class Behavior<
 
     // processing definition filter
     if (definitionFilter !== undefined) {
-      const definitionFilterArgs = parents.map((p) => p._$bindedDefinitionFilter ?? null)
-      this._$bindedDefinitionFilter = (childDef) => {
+      const definitionFilterArgs = parents.map((p) => p._$boundDefinitionFilter ?? null)
+      this._$boundDefinitionFilter = (childDef) => {
         definitionFilter(childDef, definitionFilterArgs)
       }
     }

--- a/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
@@ -26,14 +26,14 @@ type TaggedMethod<Fn extends ComponentMethod> = typeUtils.TaggedMethod<Fn>
 type UnTaggedMethod<M extends TaggedMethod<any>> = typeUtils.UnTaggedMethod<M>
 
 export class BaseBehaviorBuilder<
-  TPrevData extends DataList = Empty,
-  TData extends DataList = Empty,
-  TProperty extends PropertyList = Empty,
-  TMethod extends MethodList = Empty,
-  TChainingFilter extends ChainingFilterType = never,
-  TPendingChainingFilter extends ChainingFilterType = never,
-  TComponentExport = never,
-  TExtraThisFields extends DataList = Empty,
+  TPrevData extends DataList,
+  TData extends DataList,
+  TProperty extends PropertyList,
+  TMethod extends MethodList,
+  TChainingFilter extends ChainingFilterType,
+  TPendingChainingFilter extends ChainingFilterType,
+  TComponentExport,
+  TExtraThisFields extends DataList,
 > {
   protected _$codeSpace!: CodeSpace
   protected _$!: glassEasel.BehaviorBuilder<

--- a/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
@@ -404,7 +404,7 @@ export class BaseBehaviorBuilder<
     >,
     TChainingFilter
   > {
-    def.behaviors?.forEach((beh) => beh._$bindedDefinitionFilter?.(def))
+    def.behaviors?.forEach((beh) => beh._$boundDefinitionFilter?.(def))
     const inner = this._$
     const {
       behaviors,

--- a/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
@@ -3,7 +3,7 @@
 import { BaseBehaviorBuilder } from './base_behavior_builder'
 import { Behavior } from '../behavior'
 import type { BehaviorDefinition, utils as typeUtils } from '../types'
-import type { DefinitionFilter, GeneralBehavior } from '../behavior'
+import type { DefinitionFilter } from '../behavior'
 import type { AllData, Component, GeneralComponent } from '../component'
 import type { CodeSpace } from '../space'
 import type { ResolveBehaviorBuilder, BuilderContext } from './type_utils'
@@ -23,15 +23,26 @@ type ChainingFilterFunc<
   TRemovedFields extends string = never,
 > = typeUtils.ChainingFilterFunc<TAddedFields, TRemovedFields>
 
+export type DefaultBehaviorBuilder = BehaviorBuilder<
+  /* TPrevData */ Empty,
+  /* TData */ Empty,
+  /* TProperty */ Empty,
+  /* TMethod */ Empty,
+  /* TChainingFilter */ never,
+  /* TPendingChainingFilter */ never,
+  /* TComponentExport */ never,
+  /* TExtraThisFields */ Empty
+>
+
 export class BehaviorBuilder<
-  TPrevData extends DataList = Empty,
-  TData extends DataList = Empty,
-  TProperty extends PropertyList = Empty,
-  TMethod extends MethodList = Empty,
-  TChainingFilter extends ChainingFilterType = never,
-  TPendingChainingFilter extends ChainingFilterType = never,
-  TComponentExport = never,
-  TExtraThisFields extends DataList = Empty,
+  TPrevData extends DataList,
+  TData extends DataList,
+  TProperty extends PropertyList,
+  TMethod extends MethodList,
+  TChainingFilter extends ChainingFilterType,
+  TPendingChainingFilter extends ChainingFilterType,
+  TComponentExport,
+  TExtraThisFields extends DataList,
 > extends BaseBehaviorBuilder<
   TPrevData,
   TData,
@@ -46,11 +57,11 @@ export class BehaviorBuilder<
   private _$chainingFilter?: ChainingFilterFunc<any, any>
 
   /** @internal */
-  static create(codeSpace: CodeSpace): BehaviorBuilder {
+  static create(codeSpace: CodeSpace): DefaultBehaviorBuilder {
     const ret = new BehaviorBuilder()
     ret._$codeSpace = codeSpace
     ret._$ = codeSpace.getComponentSpace().defineWithMethodCaller()
-    return ret
+    return ret as DefaultBehaviorBuilder
   }
 
   /** Define a chaining filter */
@@ -109,7 +120,7 @@ export class BehaviorBuilder<
     >,
     UChainingFilter
   > {
-    this._$parents.push(behavior as GeneralBehavior)
+    this._$parents.push(behavior)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._$ = this._$.behavior(behavior._$)
     if (behavior._$chainingFilter) {

--- a/glass-easel-miniprogram-adapter/src/builder/index.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/index.ts
@@ -1,3 +1,5 @@
 export { BehaviorBuilder } from './behavior_builder'
+export type { DefaultBehaviorBuilder } from './behavior_builder'
 export { ComponentBuilder } from './component_builder'
+export type { DefaultComponentBuilder } from './component_builder'
 export { BuilderContext } from './type_utils'

--- a/glass-easel-miniprogram-adapter/src/builder/type_utils.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/type_utils.ts
@@ -1,6 +1,6 @@
 import type * as glassEasel from 'glass-easel'
 import type { utils as typeUtils } from '../types'
-import type { ComponentType, GeneralBehavior, TraitBehavior } from '../behavior'
+import type { GeneralComponentType, GeneralBehavior, TraitBehavior } from '../behavior'
 import type { GeneralComponent } from '../component'
 
 export type ResolveBehaviorBuilder<
@@ -33,7 +33,7 @@ export type TraitRelationParams<TOut extends { [key: string]: any }> = {
 }
 
 export type RelationParams = {
-  target?: string | ComponentType<any, any, any, any> | GeneralBehavior | TraitBehavior<any>
+  target?: string | GeneralComponentType | GeneralBehavior | TraitBehavior<any>
   type: 'ancestor' | 'descendant' | 'parent' | 'child' | 'parent-common-node' | 'child-common-node'
   linked?: (target: GeneralComponent) => void
   linkChanged?: (target: GeneralComponent) => void

--- a/glass-easel-miniprogram-adapter/src/component.ts
+++ b/glass-easel-miniprogram-adapter/src/component.ts
@@ -5,7 +5,6 @@ import { SelectorQuery } from './selector_query'
 import { IntersectionObserver } from './intersection'
 import { MediaQueryObserver } from './media_query'
 
-type Empty = typeUtils.Empty
 type DataList = typeUtils.DataList
 type PropertyList = typeUtils.PropertyList
 type MethodList = typeUtils.MethodList
@@ -19,8 +18,9 @@ type ExportType<
   UProperty extends PropertyList,
   UMethod extends MethodList,
   UComponentExport,
+  UExtraThisFields extends DataList,
 > = [UComponentExport] extends [never]
-  ? Component<UData, UProperty, UMethod, UComponentExport>
+  ? Component<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>
   : UComponentExport
 
 const filterComponentExportWithType = <
@@ -28,11 +28,12 @@ const filterComponentExportWithType = <
   UProperty extends PropertyList,
   UMethod extends MethodList,
   UComponentExport,
+  UExtraThisFields extends DataList,
 >(
-  source: ComponentCaller<any, any, any, any>,
+  source: GeneralComponentCaller,
   elem: glassEasel.Element,
-  componentType: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-): ExportType<UData, UProperty, UMethod, UComponentExport> | undefined => {
+  componentType: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | undefined => {
   const comp = elem.asInstanceOf(componentType._$)
   if (comp === null) return undefined
   const selectedSpace = comp.getRootBehavior().ownerSpace
@@ -70,17 +71,30 @@ const filterComponentExport = (
   return undefined
 }
 
-export type GeneralComponent = Component<any, any, any, any>
+export type GeneralComponent = Component<
+  /* TData */ Record<string, any>,
+  /* TProperty */ Record<string, any>,
+  /* TMethod */ Record<string, any>,
+  /* TComponentExport */ any,
+  /* TExtraThisFields */ Record<string, any>
+>
 
 export type Component<
   TData extends DataList,
   TProperty extends PropertyList,
   TMethod extends MethodList,
   TComponentExport,
-  TExtraThisFields extends DataList = Empty,
+  TExtraThisFields extends DataList,
 > = ComponentCaller<TData, TProperty, TMethod, TComponentExport> & {
   [k in keyof TMethod]: TMethod[k]
 } & TExtraThisFields
+
+type GeneralComponentCaller = ComponentCaller<
+  /* TData */ Record<string, any>,
+  /* TProperty */ Record<string, any>,
+  /* TMethod */ Record<string, any>,
+  /* TComponentExport */ any
+>
 
 export class ComponentCaller<
   TData extends DataList,
@@ -356,19 +370,21 @@ export class ComponentCaller<
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
     selector: string,
-    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport> | null
+    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | null
   selectComponent<
     UData extends DataList,
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
     selector: string,
-    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport> | null {
+    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | null {
     const target = this._$.getShadowRoot()!.querySelector(selector)
     if (target === null) return null
     return componentType
@@ -388,21 +404,23 @@ export class ComponentCaller<
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
     selector: string,
-    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport>[]
+    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>[]
   selectAllComponents<
     UData extends DataList,
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
     selector: string,
-    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport>[] {
+    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>[] {
     const targets = this._$.getShadowRoot()!.querySelectorAll(selector)
-    const ret = [] as ExportType<UData, UProperty, UMethod, UComponentExport>[]
+    const ret = [] as ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>[]
     targets.forEach((target) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const r = componentType
@@ -425,17 +443,19 @@ export class ComponentCaller<
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
-    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport> | null
+    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | null
   selectOwnerComponent<
     UData extends DataList,
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
-    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): ExportType<UData, UProperty, UMethod, UComponentExport> | null {
+    componentType?: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): ExportType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | null {
     const target = this._$.ownerShadowRoot?.getHostNode()
     if (target === undefined) return null
     return componentType
@@ -464,12 +484,19 @@ export class ComponentCaller<
     UProperty extends PropertyList,
     UMethod extends MethodList,
     UComponentExport,
+    UExtraThisFields extends DataList,
   >(
-    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport>,
-  ): Component<UData, UProperty, UMethod, UComponentExport> | null {
+    componentType: ComponentType<UData, UProperty, UMethod, UComponentExport, UExtraThisFields>,
+  ): Component<UData, UProperty, UMethod, UComponentExport, UExtraThisFields> | null {
     const inner = this._$.asInstanceOf(componentType._$)
     if (!inner) return null
-    return this as unknown as Component<UData, UProperty, UMethod, UComponentExport>
+    return this as unknown as Component<
+      UData,
+      UProperty,
+      UMethod,
+      UComponentExport,
+      UExtraThisFields
+    >
   }
 }
 
@@ -478,24 +505,33 @@ export class ComponentProto<
   TProperty extends PropertyList,
   TMethod extends MethodList,
   TComponentExport,
+  TExtraThisFields extends DataList,
 > {
-  private proto: Component<TData, TProperty, TMethod, TComponentExport>
+  private proto: Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields>
 
   constructor(
     methods: TMethod,
+    parents: GeneralBehavior[],
     componentExport?: (source: GeneralComponent | null) => TComponentExport,
   ) {
     this.proto = Object.create(ComponentCaller.prototype) as Component<
       TData,
       TProperty,
       TMethod,
-      TComponentExport
+      TComponentExport,
+      TExtraThisFields
     >
     Object.assign(this.proto, methods)
     this.proto._$export = componentExport
   }
 
-  derive(): Component<TData, TProperty, TMethod, TComponentExport> {
-    return Object.create(this.proto) as Component<TData, TProperty, TMethod, TComponentExport>
+  derive(): Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields> {
+    return Object.create(this.proto) as Component<
+      TData,
+      TProperty,
+      TMethod,
+      TComponentExport,
+      TExtraThisFields
+    >
   }
 }

--- a/glass-easel-miniprogram-adapter/src/component.ts
+++ b/glass-easel-miniprogram-adapter/src/component.ts
@@ -71,6 +71,16 @@ const filterComponentExport = (
   return undefined
 }
 
+export const determineComponentExports = (
+  parent: GeneralBehavior[],
+  selfExport: ((source: GeneralComponent | null) => any) | undefined,
+) => {
+  if (selfExport !== undefined) return selfExport
+  const targetBehavior = parent.findLast((behavior) => behavior._$export !== undefined)
+  if (targetBehavior !== undefined) return targetBehavior._$export
+  return undefined
+}
+
 export type GeneralComponent = Component<
   /* TData */ Record<string, any>,
   /* TProperty */ Record<string, any>,
@@ -522,7 +532,7 @@ export class ComponentProto<
       TExtraThisFields
     >
     Object.assign(this.proto, methods)
-    this.proto._$export = componentExport
+    this.proto._$export = determineComponentExports(parents, componentExport)
   }
 
   derive(): Component<TData, TProperty, TMethod, TComponentExport, TExtraThisFields> {

--- a/glass-easel-miniprogram-adapter/src/space.ts
+++ b/glass-easel-miniprogram-adapter/src/space.ts
@@ -14,20 +14,29 @@ import type {
   PageDefinition,
   utils as typeUtils,
 } from './types'
-import type { Behavior } from './behavior'
+import type { DefaultBehaviorBuilder, DefaultComponentBuilder } from './builder'
+import type { Behavior, ComponentType } from './behavior'
 import type { Component } from './component'
 
 // The page constructor
 export interface PageConstructor {
   <TData extends DataList, TNewExtraFields extends { [k: PropertyKey]: any }>(
     definition: PageDefinition<TData, TNewExtraFields> &
-      ThisType<Component<TData, Empty, TNewExtraFields, undefined>>,
+      ThisType<
+        Component<
+          /* TData */ TData,
+          /* TProperty */ Empty,
+          /* TMethod */ TNewExtraFields,
+          /* TComponentExport */ never,
+          /* TExtraThisFields */ Empty
+        >
+      >,
   ): void
 }
 
 // The component constructor
 export interface ComponentConstructor {
-  (): ComponentBuilder
+  (): DefaultComponentBuilder
   <
     TData extends DataList,
     TProperty extends PropertyList,
@@ -35,21 +44,51 @@ export interface ComponentConstructor {
     TComponentExport,
   >(
     definition: ComponentDefinition<TData, TProperty, TMethod, TComponentExport> &
-      ThisType<Component<TData, TProperty, TMethod, TComponentExport>>,
-  ): void
+      ThisType<
+        Component<
+          /* TData */ TData,
+          /* TProperty */ TProperty,
+          /* TMethod */ TMethod,
+          /* TComponentExport */ TComponentExport,
+          /* TExtraThisFields */ Empty
+        >
+      >,
+  ): ComponentType<
+    /* TData */ TData,
+    /* TProperty */ TProperty,
+    /* TMethod */ TMethod,
+    /* TComponentExport */ TComponentExport,
+    /* TExtraThisFields */ Empty
+  >
 }
 
 // The behavior constructor
 export interface BehaviorConstructor {
-  (): BehaviorBuilder
+  (): DefaultBehaviorBuilder
   <
     TData extends DataList,
     TProperty extends PropertyList,
     TMethod extends MethodList,
     TComponentExport,
   >(
-    definition: BehaviorDefinition<TData, TProperty, TMethod, TComponentExport>,
-  ): Behavior<TData, TProperty, TMethod, never>
+    definition: BehaviorDefinition<TData, TProperty, TMethod, TComponentExport> &
+      ThisType<
+        Component<
+          /* TData */ TData,
+          /* TProperty */ TProperty,
+          /* TMethod */ TMethod,
+          /* TComponentExport */ TComponentExport,
+          /* TExtraThisFields */ Empty
+        >
+      >,
+  ): Behavior<
+    /* TData */ TData,
+    /* TProperty */ TProperty,
+    /* TMethod */ TMethod,
+    /* TChainingFilter */ never,
+    /* TComponentExport */ TComponentExport,
+    /* TExtraThisFields */ Empty
+  >
   trait<TIn extends { [key: string]: any }>(): TraitBehavior<TIn, TIn>
   trait<TIn extends { [key: string]: any }, TOut extends { [key: string]: any }>(
     trans: (impl: TIn) => TOut,
@@ -323,19 +362,35 @@ export class CodeSpace {
       TNewExtraFields extends { [k: PropertyKey]: any },
     >(
       definition: PageDefinition<TData, TNewExtraFields> &
-        ThisType<Component<TData, Empty, TNewExtraFields, undefined>>,
+        ThisType<
+          Component<
+            /* TData */ TData,
+            /* TProperty */ Empty,
+            /* TMethod */ TNewExtraFields,
+            /* TComponentExport */ never,
+            /* TExtraThisFields */ Empty
+          >
+        >,
     ) {
       return self.component(path).pageDefinition(definition).register()
     }
 
     // The component constructor
-    function componentConstructor(): ComponentBuilder
+    function componentConstructor(): DefaultComponentBuilder
     function componentConstructor<
       TData extends DataList,
       TProperty extends PropertyList,
       TMethod extends MethodList,
       TComponentExport,
-    >(definition: ComponentDefinition<TData, TProperty, TMethod, TComponentExport>): void
+    >(
+      definition: ComponentDefinition<TData, TProperty, TMethod, TComponentExport>,
+    ): ComponentType<
+      /* TData */ TData,
+      /* TProperty */ TProperty,
+      /* TMethod */ TMethod,
+      /* TComponentExport */ TComponentExport,
+      /* TExtraThisFields */ Empty
+    >
     function componentConstructor<
       TData extends DataList,
       TProperty extends PropertyList,
@@ -349,7 +404,7 @@ export class CodeSpace {
     }
 
     // The behavior constructor
-    function behaviorConstructor(): BehaviorBuilder
+    function behaviorConstructor(): DefaultBehaviorBuilder
     function behaviorConstructor<
       TData extends DataList,
       TProperty extends PropertyList,
@@ -357,7 +412,14 @@ export class CodeSpace {
       TComponentExport,
     >(
       definition: BehaviorDefinition<TData, TProperty, TMethod, TComponentExport>,
-    ): Behavior<TData, TProperty, TMethod, never>
+    ): Behavior<
+      /* TData */ TData,
+      /* TProperty */ TProperty,
+      /* TMethod */ TMethod,
+      /* TChainingFilter */ never,
+      /* TComponentExport */ TComponentExport,
+      /* TExtraThisFields */ Empty
+    >
     function behaviorConstructor<
       TData extends DataList,
       TProperty extends PropertyList,
@@ -385,7 +447,7 @@ export class CodeSpace {
    * The method do not need a definition environment, so the global object pollution is avoided.
    * `path` should be the component path (without ".js" extension).
    */
-  component(path: string): ComponentBuilder {
+  component(path: string): DefaultComponentBuilder {
     return ComponentBuilder.create(this, path, this.waitingAliasMap[path])
   }
 
@@ -394,7 +456,7 @@ export class CodeSpace {
    *
    * The method do not need a definition environment, so the global object pollution is avoided.
    */
-  behavior(): BehaviorBuilder {
+  behavior(): DefaultBehaviorBuilder {
     return BehaviorBuilder.create(this)
   }
 

--- a/glass-easel-miniprogram-adapter/tests/env.test.ts
+++ b/glass-easel-miniprogram-adapter/tests/env.test.ts
@@ -67,7 +67,14 @@ describe('env', () => {
     )
 
     codeSpace.componentEnv('path/to/comp', ({ Behavior, Component }) => {
-      const beh = Behavior({ data: { num: 123 } })
+      const beh = Behavior({
+        data: { num: 123 },
+        methods: {
+          updateNum() {
+            this.setData({ num: 456 })
+          },
+        },
+      })
       Component().behavior(beh).register()
     })
 


### PR DESCRIPTION
1. remove default generic value from builder types and component types, which have many generics, to prevent lossing or misplacing generics during passing;
1. explicitly specifies generic values for defaults of builder types and generals for component types;
1. generic for `extraThisFields` is missing from `ComponentType`, which made `extraThisFields` not working on instance comes from `selectComponent*`
1. `Component` from `space.componentEnv` with a definition should returns a `ComponentType` rather than `void`
1. `Behavior` from `space.componentEnv` with a definition should have a corresponding `Component` as its `ThisType` for accessing `this` in methods or lifetimes (similars to `BehaviorBuilder.definition` in core)
1. components and behaviors should be able to use `export` from behaviors which they are using