### PR TITLE
feat(miniprogram-adapter): make component builder and behavior builder shares `behavior` impl

### DIFF
--- a/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/base_behavior_builder.ts
@@ -83,6 +83,45 @@ export class BaseBehaviorBuilder<
     return this as any
   }
 
+  /** Use another behavior */
+  behavior<
+    UData extends DataList,
+    UProperty extends PropertyList,
+    UMethod extends MethodList,
+    UChainingFilter extends ChainingFilterType,
+    UComponentExport,
+    UExtraThisFields extends DataList,
+  >(
+    behavior: Behavior<
+      UData,
+      UProperty,
+      UMethod,
+      UChainingFilter,
+      UComponentExport,
+      UExtraThisFields
+    >,
+  ): ResolveBehaviorBuilder<
+    BaseBehaviorBuilder<
+      TPrevData,
+      TData & UData,
+      TProperty & UProperty,
+      TMethod & UMethod,
+      UChainingFilter,
+      TPendingChainingFilter,
+      UComponentExport,
+      TExtraThisFields & UExtraThisFields
+    >,
+    UChainingFilter
+  > {
+    this._$parents.push(behavior)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    this._$ = this._$.behavior(behavior._$)
+    if (behavior._$chainingFilter) {
+      return behavior._$chainingFilter(this as any)
+    }
+    return this as any
+  }
+
   data<T extends DataList>(
     gen: () => typeUtils.NewFieldList<AllData<TData, TProperty>, T>,
   ): ResolveBehaviorBuilder<

--- a/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/behavior_builder.ts
@@ -91,7 +91,7 @@ export class BehaviorBuilder<
   }
 
   /** Use another behavior */
-  behavior<
+  override behavior<
     UData extends DataList,
     UProperty extends PropertyList,
     UMethod extends MethodList,
@@ -115,18 +115,12 @@ export class BehaviorBuilder<
       TMethod & UMethod,
       UChainingFilter,
       TPendingChainingFilter,
-      TComponentExport,
+      UComponentExport,
       TExtraThisFields & UExtraThisFields
     >,
     UChainingFilter
   > {
-    this._$parents.push(behavior)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this._$ = this._$.behavior(behavior._$)
-    if (behavior._$chainingFilter) {
-      return behavior._$chainingFilter(this as any)
-    }
-    return this as any
+    return super.behavior(behavior) as any
   }
 
   /** Set the export value when the component is being selected */

--- a/glass-easel-miniprogram-adapter/src/builder/component_builder.ts
+++ b/glass-easel-miniprogram-adapter/src/builder/component_builder.ts
@@ -100,7 +100,7 @@ export class ComponentBuilder<
   }
 
   /** Use another behavior */
-  behavior<
+  override behavior<
     UData extends DataList,
     UProperty extends PropertyList,
     UMethod extends MethodList,
@@ -129,17 +129,7 @@ export class ComponentBuilder<
     >,
     UChainingFilter
   > {
-    this._$parents.push(behavior)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this._$ = this._$.behavior(behavior._$)
-    if (behavior._$export) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      this._$export = behavior._$export as any
-    }
-    if (behavior._$chainingFilter) {
-      return behavior._$chainingFilter(this as any)
-    }
-    return this as any
+    return super.behavior(behavior) as any
   }
 
   /** Set the export value when the component is being selected */


### PR DESCRIPTION
component export is now handled by `determineComponentExports`, so `behaviorBuilder` and `componentBuilder` can now share a `behavior` call impl