### PR TITLE
fix: avoid removal/insertion when removal one of last 2 shared-keys

### DIFF
--- a/glass-easel/src/tmpl/range_list_diff.ts
+++ b/glass-easel/src/tmpl/range_list_diff.ts
@@ -104,14 +104,13 @@ export class RangeListManager {
         const rawKeyField = keyName === '*this' ? item : item?.[keyName]
         const rawKey = rawKeyField !== undefined && rawKeyField !== null ? String(rawKeyField) : ''
         rawKeys[i] = rawKey
-        if (keyMap[rawKey] !== undefined) {
+        if (sharedKeyMap?.[rawKey]) {
+          sharedKeyMap[rawKey]!.push(i)
+        } else if (keyMap[rawKey] !== undefined) {
           if (!sharedKeyMap) {
             sharedKeyMap = Object.create(null) as { [key: string]: number[] }
           }
           sharedKeyMap[rawKey] = [keyMap[rawKey]!, i]
-          delete keyMap[rawKey]
-        } else if (sharedKeyMap?.[rawKey]) {
-          sharedKeyMap[rawKey]!.push(i)
         } else {
           keyMap[rawKey] = i
         }
@@ -128,7 +127,7 @@ export class RangeListManager {
           const key = keys[i]!
           const items = sharedKeyMap[key]!
           let inc = 0
-          for (let j = 0; j < items.length; j += 1) {
+          for (let j = 1; j < items.length; j += 1) {
             const index = items[j]!
             while (keyMap[`${key}--${inc}`] !== undefined) inc += 1
             const k = `${key}--${inc}`
@@ -210,14 +209,18 @@ export class RangeListManager {
           const k = newRawKeys[i]!
           let isSharedKey = false
           if (oldSharedKeyMap || newSharedKeyMap) {
-            const splitPos = k.lastIndexOf('--')
-            if (splitPos >= 0) {
-              const oriKey = k.slice(0, splitPos)
-              if (
-                oldSharedKeyMap?.[oriKey] !== undefined ||
-                newSharedKeyMap?.[oriKey] !== undefined
-              ) {
-                isSharedKey = true
+            if (oldSharedKeyMap?.[k] !== undefined || newSharedKeyMap?.[k] !== undefined) {
+              isSharedKey = true
+            } else {
+              const splitPos = k.lastIndexOf('--')
+              if (splitPos >= 0) {
+                const oriKey = k.slice(0, splitPos)
+                if (
+                  oldSharedKeyMap?.[oriKey] !== undefined ||
+                  newSharedKeyMap?.[oriKey] !== undefined
+                ) {
+                  isSharedKey = true
+                }
               }
             }
           }

--- a/glass-easel/tests/core/data_update.test.ts
+++ b/glass-easel/tests/core/data_update.test.ts
@@ -366,13 +366,13 @@ describe('partial update', () => {
       })
     })
     expect(getP()).toStrictEqual(['A', 'B', 'C'])
-    expect(execArr).toStrictEqual(['A', 'B', 'C'])
+    expect(execArr).toStrictEqual(['B', 'A', 'C'])
     execArr = []
     comp.groupUpdates(() => {
       comp.replaceDataOnPath(['list', 1, 'k'], 3)
     })
     expect(getP()).toStrictEqual(['A', 'B', 'C'])
-    expect(execArr).toStrictEqual(['A', 'B'])
+    expect(execArr).toStrictEqual(['B', 'A'])
     execArr = []
     comp.groupUpdates(() => {
       comp.replaceDataOnPath(['list', 2, 'k'], 4)
@@ -386,7 +386,7 @@ describe('partial update', () => {
       })
     })
     expect(getP()).toStrictEqual(['A', 'B', 'C'])
-    expect(execArr).toStrictEqual(['B', 'C'])
+    expect(execArr).toStrictEqual(['C', 'B'])
   })
 
   test('should be able to do list-splice update (without key)', () => {
@@ -612,7 +612,7 @@ describe('partial update', () => {
       })
     })
     expect(getP()).toStrictEqual(['G', 'D', 'E', 'GG'])
-    expect(execArr).toStrictEqual(['G', 'GG'])
+    expect(execArr).toStrictEqual(['GG', 'G'])
     execArr = []
     execWithWarn(1, () => {
       comp.groupUpdates(() => {


### PR DESCRIPTION
When wx:key is invalid and a unique key becomes shared key during updates, e.g. `[ { key: 'a' } ]` changed to `[ { key: 'a' }, { key: 'a' } ]` , it causes an extra removal+insertion. This PR fixes this behavior.