### PR TITLE
Allow `data-*` in template attrs to be component properties and external classes

### DIFF
--- a/glass-easel-template-compiler/src/escape.rs
+++ b/glass-easel-template-compiler/src/escape.rs
@@ -46,3 +46,16 @@ pub(crate) fn dash_to_camel(s: &str) -> CompactString {
     }
     camel_name
 }
+
+pub(crate) fn camel_to_dash(s: &str) -> CompactString {
+    let mut dash_name = CompactString::new("");
+    for c in s.chars() {
+        if c.is_ascii_uppercase() {
+            dash_name.push('-');
+            dash_name.push(c.to_ascii_lowercase());
+        } else {
+            dash_name.push(c);
+        }
+    }
+    dash_name
+}

--- a/glass-easel-template-compiler/src/parse/tag.rs
+++ b/glass-easel-template-compiler/src/parse/tag.rs
@@ -845,9 +845,7 @@ impl Element {
                             (_, "slot") => AttrPrefixKind::Slot,
                             (ElementKind::Normal { .. }, "class") => AttrPrefixKind::ClassString,
                             (ElementKind::Normal { .. }, "style") => AttrPrefixKind::StyleString,
-                            (ElementKind::Normal { .. }, x) | (ElementKind::Slot { .. }, x)
-                                if x.starts_with("data-") =>
-                            {
+                            (ElementKind::Slot { .. }, x) if x.starts_with("data-") => {
                                 AttrPrefixKind::DataHyphen
                             }
                             _ => AttrPrefixKind::Normal,
@@ -4076,9 +4074,7 @@ mod test {
         case!("<div data:aB></div>", r#"<div data:aB/>"#);
         case!(
             "<div data-a-bC='fn'></div>",
-            r#"<div data:aBc="fn"/>"#,
-            ParseErrorKind::AvoidUppercaseLetters,
-            5..14
+            r#"<div data-a-bC="fn"/>"#
         );
         case!("<div generic:a='A'></div>", r#"<div generic:a="A"/>"#);
         case!(

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -95,6 +95,11 @@ const dashToCamelCase = (dash: string): string => {
   return ret
 }
 
+const camelToDashCase = (dash: string): string => {
+  const ret = dash.replace(/[A-Z]/g, (s) => `-${s.toLowerCase()}`)
+  return ret
+}
+
 export interface ProcGen {
   (wrapper: ProcGenWrapper, isCreation: true, data: DataValue): {
     C: DefineChildren
@@ -1102,8 +1107,26 @@ export class ProcGenWrapper {
   }
 
   // set dataset
-  d = (elem: Element, name: string, v: unknown) => {
-    elem.setDataset(name, v)
+  d = (elem: Element, name: string, v: unknown, fallbackDataHyphen: boolean) => {
+    if (fallbackDataHyphen && isComponent(elem)) {
+      const nodeDataProxy = Component.getDataProxy(elem)
+      const fullName = `data${name[0]!.toUpperCase()}${name.slice(1)}`
+      if (nodeDataProxy.replaceProperty(fullName, v)) {
+        // empty
+      } else {
+        const fullDashName = `data-${camelToDashCase(name)}`
+        if (elem.hasExternalClass(fullDashName)) {
+          elem.setExternalClass(fullDashName, v as string)
+        } else if (nodeDataProxy.replaceProperty(fullDashName, v)) {
+          // leave for compatibilities
+        } else {
+          elem.setDataset(name, v)
+        }
+      }
+      this.tryCallPropertyChangeListener(elem, name, v)
+    } else {
+      elem.setDataset(name, v)
+    }
   }
 
   // set mark
@@ -1185,13 +1208,6 @@ export class ProcGenWrapper {
         }
       } else if (elem.hasExternalClass(name)) {
         elem.setExternalClass(name, v as string)
-      } else if (name.startsWith('data-')) {
-        // compatibilities for legacy data-* properties
-        if (nodeDataProxy.replaceProperty(name, v)) {
-          // empty
-        } else {
-          elem.setDataset(dashToCamelCase(name.slice(5).toLowerCase()), v)
-        }
       } else {
         // compatibilities for legacy event binding syntax
         if (!this.checkFallbackEventListener(elem, camelName, v, generalLvaluePath)) {
@@ -1203,9 +1219,7 @@ export class ProcGenWrapper {
         }
       }
     } else if (isNativeNode(elem)) {
-      if (name.startsWith('data-')) {
-        elem.setDataset(dashToCamelCase(name.slice(5).toLowerCase()), v)
-      } else if (this.fallbackListenerOnNativeNode) {
+      if (this.fallbackListenerOnNativeNode) {
         // compatibilities for legacy event binding syntax
         const camelName = dashToCamelCase(name)
         if (!this.checkFallbackEventListener(elem, camelName, v, generalLvaluePath)) {

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -1185,6 +1185,13 @@ export class ProcGenWrapper {
         }
       } else if (elem.hasExternalClass(name)) {
         elem.setExternalClass(name, v as string)
+      } else if (name.startsWith('data-')) {
+        // compatibilities for legacy data-* properties
+        if (nodeDataProxy.replaceProperty(name, v)) {
+          // empty
+        } else {
+          elem.setDataset(dashToCamelCase(name.slice(5).toLowerCase()), v)
+        }
       } else {
         // compatibilities for legacy event binding syntax
         if (!this.checkFallbackEventListener(elem, camelName, v, generalLvaluePath)) {
@@ -1196,7 +1203,9 @@ export class ProcGenWrapper {
         }
       }
     } else if (isNativeNode(elem)) {
-      if (this.fallbackListenerOnNativeNode) {
+      if (name.startsWith('data-')) {
+        elem.setDataset(dashToCamelCase(name.slice(5).toLowerCase()), v)
+      } else if (this.fallbackListenerOnNativeNode) {
         // compatibilities for legacy event binding syntax
         const camelName = dashToCamelCase(name)
         if (!this.checkFallbackEventListener(elem, camelName, v, generalLvaluePath)) {

--- a/glass-easel/tests/tmpl/structure.test.ts
+++ b/glass-easel/tests/tmpl/structure.test.ts
@@ -1603,6 +1603,62 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     matchElementWithDom(elem)
   })
 
+  test('setting element dataset', () => {
+    const subComp = glassEasel.registerElement({
+      template: tmpl(`
+        <slot id="a" data:a-b="789" />
+      `),
+    })
+    const def = glassEasel
+      .registerElement({
+        using: {
+          'sub-comp': subComp,
+        },
+        template: tmpl(`
+          <sub-comp id="sub" data:a-b="456">
+            <div id="a" data:a-b="123" />
+          </sub-comp>
+        `),
+      })
+      .general()
+    const elem = glassEasel.Component.createWithContext('root', def, testBackend)
+    glassEasel.Element.pretendAttached(elem)
+    expect(domHtml(elem)).toBe('<sub-comp><div></div></sub-comp>')
+    matchElementWithDom(elem)
+    expect(elem.getShadowRoot()!.getElementById('a')!.dataset['a-b']).toBe('123')
+    const sub = elem.getShadowRoot()!.getElementById('sub')!.asGeneralComponent()!
+    expect(sub.dataset['a-b']).toBe('456')
+    expect(sub.getShadowRoot()!.getElementById('a')!.dataset['a-b']).toBe('789')
+  })
+
+  test('setting element dataset (legacy syntax)', () => {
+    const subComp = glassEasel.registerElement({
+      template: tmpl(`
+        <slot id="a" data-a-b="789" />
+      `),
+    })
+    const def = glassEasel
+      .registerElement({
+        using: {
+          'sub-comp': subComp,
+        },
+        template: tmpl(`
+          <sub-comp id="sub" data-a-b="456">
+            <div id="a" data-a-b="123" />
+          </sub-comp>
+        `),
+      })
+      .general()
+    const elem = glassEasel.Component.createWithContext('root', def, testBackend)
+    glassEasel.Element.pretendAttached(elem)
+    expect(domHtml(elem)).toBe('<sub-comp><div></div></sub-comp>')
+    matchElementWithDom(elem)
+    expect(elem.getShadowRoot()!.getElementById('a')!.dataset.aB).toBe('123')
+    const sub = elem.getShadowRoot()!.getElementById('sub')!.asGeneralComponent()!
+    expect(sub.dataset.aB).toBe('456')
+    expect(sub.getShadowRoot()!.getElementById('a')!.dataset.aB).toBe('789')
+  })
+
   test('setting slot name', () => {
     const subComp = glassEasel.registerElement({
       options: {
@@ -1779,11 +1835,13 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     const cs = new glassEasel.ComponentSpace()
     const subComp = cs.defineComponent({
       template: tmpl(`
-        <div class="{{style}} a-{{propA + 1}}"></div>
+        <div hidden="{{a}} {{style}} a-{{propA + 1}} b-{{dataB + 1}}"></div>
       `),
       properties: {
+        a: Boolean,
         style: String,
         propA: Number,
+        dataB: String,
       },
     })
     const def = cs
@@ -1792,13 +1850,13 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
           'sub-comp': subComp.general(),
         },
         template: tmpl(`
-          <sub-comp style="abc" prop-a="3" />
+          <sub-comp a style="abc" prop-a="3" data-b="5" />
         `),
       })
       .general()
     const elem = glassEasel.Component.createWithContext('root', def, testBackend)
     glassEasel.Element.pretendAttached(elem)
-    expect(domHtml(elem)).toBe('<sub-comp><div class="abc a-4"></div></sub-comp>')
+    expect(domHtml(elem)).toBe('<sub-comp><div hidden="true abc a-4 b-51"></div></sub-comp>')
     matchElementWithDom(elem)
   })
 
@@ -1864,9 +1922,9 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     )
     const ssm = cs.styleScopeManager
     const subComp = cs.defineComponent({
-      externalClasses: ['class', 'ext-class'],
+      externalClasses: ['class', 'data-class'],
       template: tmpl(`
-        <div class="class ext-class"></div>
+        <div class="class data-class"></div>
       `),
       data: {
         a: 's',
@@ -1881,7 +1939,7 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
           'sub-comp': subComp.general(),
         },
         template: tmpl(`
-        <sub-comp class="static {{ dynamic || '' }}" ext-class="a-class" />
+        <sub-comp class="static {{ dynamic || '' }}" data-class="a-class" />
       `),
       })
       .general()


### PR DESCRIPTION
RT

In legacy framework, `data-xxx` is also treated as component property names in dash form! This fix also includes compatibilities for this behavior.