### PR TITLE
Support style scope inheriting

### DIFF
--- a/glass-easel-shadow-sync/src/backend.ts
+++ b/glass-easel-shadow-sync/src/backend.ts
@@ -705,6 +705,7 @@ export class ShadowSyncBackendContext implements GlassEaselBackend.Context {
             )
           } else if (glassEasel.Component.isComponent(elem)) {
             const options = elem.getComponentOptions()
+            const [styleScope, extraStyleScope] = elem.getStyleScopes()
             be = ShadowSyncElement._prepareComponent(
               this,
               getShadowSyncElement(elem),
@@ -712,8 +713,8 @@ export class ShadowSyncBackendContext implements GlassEaselBackend.Context {
               elem.tagName,
               elem.isExternal(),
               elem.isVirtual(),
-              options.styleScope ?? glassEasel.StyleScopeManager.globalScope(),
-              options.extraStyleScope,
+              styleScope ?? glassEasel.StyleScopeManager.globalScope(),
+              extraStyleScope,
               Object.keys(elem.getExternalClasses()),
               elem.getShadowRoot()?.getSlotMode() ?? null,
               options.writeIdToDOM,

--- a/glass-easel-shadow-sync/src/replay.ts
+++ b/glass-easel-shadow-sync/src/replay.ts
@@ -139,16 +139,19 @@ export function replayShadowBackend(
       const options = elem.getComponentOptions()
       be =
         handlers.createElement?.(ownerShadowRoot, elem) ||
-        ownerShadowRoot.createComponent(
-          elem.tagName,
-          elem.isExternal(),
-          elem.isVirtual(),
-          options.styleScope ?? glassEasel.StyleScopeManager.globalScope(),
-          options.extraStyleScope,
-          Object.keys(elem.getExternalClasses()),
-          elem.getShadowRoot()?.getSlotMode() ?? null,
-          options.writeIdToDOM,
-        )
+        (() => {
+          const [styleScope, extraStyleScope] = elem.getStyleScopes()
+          return ownerShadowRoot.createComponent(
+            elem.tagName,
+            elem.isExternal(),
+            elem.isVirtual(),
+            styleScope ?? glassEasel.StyleScopeManager.globalScope(),
+            extraStyleScope,
+            Object.keys(elem.getExternalClasses()),
+            elem.getShadowRoot()?.getSlotMode() ?? null,
+            options.writeIdToDOM,
+          )
+        })()
       be.__wxElement = elem
       be.associateValue(elem)
       setAttributes(elem, be)

--- a/glass-easel/src/global_options.ts
+++ b/glass-easel/src/global_options.ts
@@ -55,6 +55,8 @@ export type ComponentOptions = {
   styleScope?: StyleScopeId
   /** An extra style scope assigned to the component */
   extraStyleScope?: StyleScopeId | null
+  /** Inherit style scope from parent component or not */
+  inheritStyleScope?: boolean
   /** Enable multiple slots or not */
   multipleSlots?: boolean
   /** Enable dynamic slots or not */
@@ -95,6 +97,7 @@ export type NormalizedComponentOptions = {
   templateEngine: TemplateEngine | null
   styleScope: StyleScopeId | null
   extraStyleScope: StyleScopeId | null
+  inheritStyleScope: boolean
   multipleSlots: boolean
   dynamicSlots: boolean
   reflectToAttributes: boolean
@@ -139,6 +142,7 @@ export const globalOptions: NormalizedComponentOptions & EnvironmentOptions = {
   templateEngine: null,
   styleScope: null,
   extraStyleScope: null,
+  inheritStyleScope: false,
   hostNodeTagName: 'wx-x',
   multipleSlots: false,
   dynamicSlots: false,
@@ -177,6 +181,8 @@ export const normalizeComponentOptions = (
     styleScope: p.styleScope !== undefined ? p.styleScope : b.styleScope,
     hostNodeTagName: p.hostNodeTagName !== undefined ? p.hostNodeTagName : b.hostNodeTagName,
     extraStyleScope: p.extraStyleScope !== undefined ? p.extraStyleScope : b.extraStyleScope,
+    inheritStyleScope:
+      p.inheritStyleScope !== undefined ? p.inheritStyleScope : b.inheritStyleScope,
     multipleSlots: p.multipleSlots !== undefined ? p.multipleSlots : b.multipleSlots,
     dynamicSlots: p.dynamicSlots !== undefined ? p.dynamicSlots : b.dynamicSlots,
     reflectToAttributes:

--- a/glass-easel/src/native_node.ts
+++ b/glass-easel/src/native_node.ts
@@ -58,26 +58,26 @@ export class NativeNode extends Element {
     node._$initialize(false, backendElement, owner, owner._$nodeTreeContext)
     node._$placeholderHandlerRemover = placeholderHandlerRemover
     const ownerHost = owner.getHostNode()
-    const ownerComponentOptions = ownerHost.getComponentOptions()
-    const styleScope = ownerComponentOptions.styleScope ?? StyleScopeManager.globalScope()
-    const extraStyleScope = ownerComponentOptions.extraStyleScope ?? undefined
-    const styleScopeManager = ownerHost._$behavior.ownerSpace.styleScopeManager
+    const [styleScope, extraStyleScope, styleScopeManager] = ownerHost.getStyleScopes()
     node.classList = new ClassList(
       node,
       undefined,
       ownerHost.classList,
-      styleScope,
-      extraStyleScope,
+      styleScope ?? StyleScopeManager.globalScope(),
+      extraStyleScope ?? undefined,
       styleScopeManager,
     )
     if (backendElement) {
       if (BM.COMPOSED || (BM.DYNAMIC && owner.getBackendMode() === BackendMode.Composed)) {
         if (ENV.DEV) performanceMeasureStart('backend.setStyleScope')
-        ;(backendElement as composedBackend.Element).setStyleScope(styleScope, extraStyleScope)
+        ;(backendElement as composedBackend.Element).setStyleScope(
+          styleScope ?? StyleScopeManager.globalScope(),
+          extraStyleScope ?? undefined,
+        )
         if (ENV.DEV) performanceMeasureEnd()
       }
       if (globalOptions.writeExtraInfoToAttr) {
-        const prefix = styleScopeManager.queryName(styleScope)
+        const prefix = styleScopeManager.queryName(styleScope ?? StyleScopeManager.globalScope())
         if (prefix) {
           backendElement.setAttribute('exparser:info-class-prefix', `${prefix}--`)
         }

--- a/glass-easel/tests/base/shadow_backend.ts
+++ b/glass-easel/tests/base/shadow_backend.ts
@@ -415,7 +415,7 @@ abstract class Node implements glassEasel.backend.Element {
       const comp = this.__wxElement?.asGeneralComponent()
       if (comp) {
         const def = comp.getComponentDefinition()
-        const scope = def.getComponentOptions().styleScope
+        const [scope] = comp.getStyleScopes()
         if (scope && scope !== def.behavior.ownerSpace._$sharedStyleScope) {
           props['wx-host'] = def.behavior.ownerSpace.styleScopeManager.queryName(scope)!
         }


### PR DESCRIPTION
In order to support a full-functioning `rich-text` component, which inherits the style scope from its parent component.