### PR TITLE
Refactor external component for shadow backend

### DIFF
--- a/glass-easel-shadow-sync/tests/base/env.ts
+++ b/glass-easel-shadow-sync/tests/base/env.ts
@@ -90,6 +90,7 @@ const createDataContext = (dataComponentSpace: glassEasel.ComponentSpace) => {
   )
 
   const shadowSyncBackend = new ShadowSyncBackendContext(
+    glassEasel,
     messageChannelDataSide,
     dataComponentSpace.styleScopeManager,
     getLinearIdGenerator,

--- a/glass-easel/src/backend/backend_protocol.ts
+++ b/glass-easel/src/backend/backend_protocol.ts
@@ -49,7 +49,6 @@ export interface Element extends Partial<suggestedBackend.Element<Element>> {
   setSlot(name: string): void
   setSlotName(slot: string): void
   setSlotElement(slot: Element | null): void
-  setExternalSlot(slot: Element): void
   setInheritSlots(): void
   setStyle(styleText: string, styleSegmentIndex: number): void
   addClass(className: string): void

--- a/glass-easel/src/backend/empty_backend.ts
+++ b/glass-easel/src/backend/empty_backend.ts
@@ -167,10 +167,6 @@ export class EmptyBackendElement implements Element {
     // empty
   }
 
-  setExternalSlot(_slot: EmptyBackendElement): void {
-    // empty
-  }
-
   setInheritSlots(): void {
     // empty
   }

--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -866,10 +866,6 @@ export class Component<
     // init data
     const shadowRoot = tmplInst.shadowRoot
     comp.shadowRoot = shadowRoot
-    if (external && (BM.SHADOW || (BM.DYNAMIC && nodeTreeContext!.mode === BackendMode.Shadow))) {
-      const slot = (shadowRoot as ExternalShadowRoot).slot as backend.Element
-      ;(backendElement as backend.Element).setExternalSlot(slot)
-    }
     const dataGroup = new DataGroup(
       comp,
       data as DataWithPropertyValues<TData, TProperty>,

--- a/glass-easel/tests/base/shadow_backend.ts
+++ b/glass-easel/tests/base/shadow_backend.ts
@@ -242,7 +242,6 @@ abstract class Node implements glassEasel.backend.Element {
   public _$nodeSlot: string = ''
   public _$slotName: string | null = null
   public _$slotElement: NativeNode | VirtualNode | null = null
-  public _$externalSlot: Element | null = null
   public _$inheritSlots: boolean = false
   public _$styleSegments: string[] = []
   public _$styleScope = 0
@@ -326,12 +325,6 @@ abstract class Node implements glassEasel.backend.Element {
       return recNonVirtual(this.shadowRoot as ShadowRoot)
     }
     const ownerHost = this._$ownerShadowRoot?.hostNode
-    if (ownerHost?.external && (ownerHost._$externalSlot as any) === this) {
-      for (let i = 0; i < ownerHost._$childNodes.length; i += 1) {
-        if (recNonVirtual(ownerHost._$childNodes[i]!) === false) return false
-      }
-      return true
-    }
     if (this._$slotName !== null) {
       if (!ownerHost) return true
       return ownerHost.forEachSlotContentInSpecifiedSlot(this as unknown as Element, recNonVirtual)
@@ -669,11 +662,6 @@ abstract class Node implements glassEasel.backend.Element {
   setSlotElement(slot: NativeNode | VirtualNode | null): void {
     assertTypes(slot, [NativeNode, VirtualNode, null])
     this._$slotElement = slot
-  }
-
-  setExternalSlot(slot: Element): void {
-    assertType(slot, Element)
-    this._$externalSlot = slot
   }
 
   setInheritSlots(): void {
@@ -1022,7 +1010,6 @@ export class Component extends Element {
   }
 
   calcContainingSlot(elem: Node | null): NativeNode | VirtualNode | null {
-    if (this.external) return this._$externalSlot
     if (this.slotMode === SlotMode.Single) {
       let singleSlot: NativeNode | VirtualNode | null = null
       this.forEachChildNodes((node) => {

--- a/glass-easel/tests/core/mutation_observer.test.ts
+++ b/glass-easel/tests/core/mutation_observer.test.ts
@@ -199,7 +199,7 @@ describe('MutationObserver', () => {
     })
     observer.observe(slot, { properties: 'all' })
     shadowRoot.setDynamicSlotHandler(
-      ['someValue'],
+      () => {},
       () => {},
       () => {},
       () => {},

--- a/glass-easel/tests/core/slot.test.ts
+++ b/glass-easel/tests/core/slot.test.ts
@@ -990,18 +990,18 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
           '<c1><child><x>C</x><x>B</x><x>C</x><x>B</x></child><a></a></c1><c2><child><x>C</x><x>B</x><x>C</x><x>B</x></child><a></a></c2><c3><child><x>C</x><x>B</x><x>C</x><x>B</x></child><a></a></c3>',
         )
         expect(ops).toEqual([
+          [-2, '3:C'],
+          [-2, '3:B'],
+          [-2, '3:C'],
+          [-2, '3:B'],
+          [-2, '3:C'],
+          [-2, '3:B'],
+          [-2, '3:C'],
+          [-2, '3:B'],
           [-1, '3:C'],
           [-1, '3:B'],
           [-1, '3:C'],
           [-1, '3:B'],
-          [-2, '3:C'],
-          [-2, '3:B'],
-          [-2, '3:C'],
-          [-2, '3:B'],
-          [-2, '3:C'],
-          [-2, '3:B'],
-          [-2, '3:C'],
-          [-2, '3:B'],
         ])
         matchElementWithDom(parentElem)
 

--- a/glass-easel/tests/legacy/virtual.test.js
+++ b/glass-easel/tests/legacy/virtual.test.js
@@ -117,7 +117,7 @@ const testCases = function (testBackend) {
       matchElementWithDom(e1)
     })
 
-    it('should work in a native-rendered root', function () {
+    if (testBackend !== shadowBackend) it('should work in a native-rendered root', function () {
       regElem({
         is: 'virtual-node-a',
         options: {
@@ -127,16 +127,8 @@ const testCases = function (testBackend) {
               ? undefined
               : getCustomExternalTemplateEngine((comp) => {
                   var root = comp.getBackendElement()
-                  var slot
-                  if (testBackend === shadowBackend) {
-                    var shadowRoot = root.getShadowRoot()
-                    slot = shadowRoot.createElement('div', 'div')
-                    slot.setSlotName('')
-                    shadowRoot.appendChild(slot)
-                  } else {
-                    slot = testBackend.createElement('div', 'div')
-                    root.appendChild(slot)
-                  }
+                  var slot = testBackend.createElement('div', 'div')
+                  root.appendChild(slot)
                   return {
                     root,
                     slot,


### PR DESCRIPTION
Primary changes:
+ Deleting external support for shadow backend, as we shouldn't expecting an external component in shadow-backend mode.
+ Moving some logic for dynamic sloting into template engine.
+ Refactoring dynamic sloting implementation in glass-easel-shadow-sync, in order to support writing dynamic slotting template in the view side.