### PR TITLE
Remove subclass 'is' property, add generator iterators and native node utils

### DIFF
--- a/glass-easel-shadow-sync/src/backend.ts
+++ b/glass-easel-shadow-sync/src/backend.ts
@@ -373,6 +373,26 @@ export class ShadowSyncElement implements GlassEaselBackend.Element {
     }
   }
 
+  createResizeObserver(
+    mode: GlassEaselBackend.ResizeObserverMode,
+    listener: (res: GlassEaselBackend.ResizeStatus) => void,
+  ): GlassEaselBackend.Observer {
+    const id = this.getChannel().createResizeObserver(this._id, mode, listener)
+    return {
+      disconnect: () => {
+        this.getChannel().disconnectObserver(id)
+      },
+    }
+  }
+
+  triggerNativeEvent(type: string, detail: unknown): void {
+    this.getChannel().triggerNativeEvent(this._id, type, detail)
+  }
+
+  manipulateNativeNode(action: string, args: unknown, cb: (res: unknown) => void): void {
+    this.getChannel().manipulateNativeNode(this._id, action, args, cb)
+  }
+
   getContext(cb: (res: any) => void): void {
     this.getChannel().getContext(this._id, cb)
   }

--- a/glass-easel-shadow-sync/src/message_channel.ts
+++ b/glass-easel-shadow-sync/src/message_channel.ts
@@ -29,6 +29,8 @@ export const enum ChannelEventType {
   MEDIA_QUERY_OBSERVER_CALLBACK,
   CREATE_INTERSECTION_OBSERVER,
   INTERSECTION_OBSERVER_CALLBACK,
+  CREATE_RESIZE_OBSERVER,
+  RESIZE_OBSERVER_CALLBACK,
   DISCONNECT_OBSERVER,
 
   CREATE_ELEMENT,
@@ -103,6 +105,9 @@ export const enum ChannelEventType {
   START_OVERLAY_INSPECT,
   START_OVERLAY_INSPECT_CALLBACK,
   STOP_OVERLAY_INSPECT,
+  TRIGGER_NATIVE_EVENT,
+  MANIPULATE_NATIVE_NODE,
+  MANIPULATE_NATIVE_NODE_CALLBACK,
 
   PERFORMANCE_START_TRACE,
   PERFORMANCE_END_TRACE,
@@ -122,6 +127,7 @@ export type ChannelEventTypeViewSide =
   | ChannelEventType.RENDER_CALLBACK
   | ChannelEventType.MEDIA_QUERY_OBSERVER_CALLBACK
   | ChannelEventType.INTERSECTION_OBSERVER_CALLBACK
+  | ChannelEventType.RESIZE_OBSERVER_CALLBACK
   | ChannelEventType.SET_MODEL_BINDING_STAT_CALLBACK
   | ChannelEventType.GET_ALL_COMPUTED_STYLES_CALLBACK
   | ChannelEventType.GET_PSEUDO_COMPUTED_STYLES_CALLBACK
@@ -133,6 +139,7 @@ export type ChannelEventTypeViewSide =
   | ChannelEventType.GET_BOX_MODEL_CALLBACK
   | ChannelEventType.GET_PSEUDO_TYPES_CALLBACK
   | ChannelEventType.START_OVERLAY_INSPECT_CALLBACK
+  | ChannelEventType.MANIPULATE_NATIVE_NODE_CALLBACK
   | ChannelEventType.GET_CONTEXT_CALLBACK
   | ChannelEventType.ON_CREATE_EVENT
   | ChannelEventType.ON_EVENT
@@ -164,6 +171,8 @@ export type ChannelArgs = ExhaustiveChannelEvent<{
   [ChannelEventType.MEDIA_QUERY_OBSERVER_CALLBACK]: [number, string]
   [ChannelEventType.CREATE_INTERSECTION_OBSERVER]: [number, number | null, string, number[], number]
   [ChannelEventType.INTERSECTION_OBSERVER_CALLBACK]: [number, string]
+  [ChannelEventType.CREATE_RESIZE_OBSERVER]: [number, number, number]
+  [ChannelEventType.RESIZE_OBSERVER_CALLBACK]: [number, string]
   [ChannelEventType.DISCONNECT_OBSERVER]: [number]
 
   [ChannelEventType.CREATE_ELEMENT]: [number, string, string, number]
@@ -262,6 +271,9 @@ export type ChannelArgs = ExhaustiveChannelEvent<{
   [ChannelEventType.START_OVERLAY_INSPECT]: [number]
   [ChannelEventType.START_OVERLAY_INSPECT_CALLBACK]: [number, string, number | null]
   [ChannelEventType.STOP_OVERLAY_INSPECT]: []
+  [ChannelEventType.TRIGGER_NATIVE_EVENT]: [number, string, string]
+  [ChannelEventType.MANIPULATE_NATIVE_NODE]: [number, string, string, number]
+  [ChannelEventType.MANIPULATE_NATIVE_NODE_CALLBACK]: [number, string]
 
   [ChannelEventType.INSERT_DYNAMIC_SLOT]: [number, [number, string, string][]]
   [ChannelEventType.UPDATE_DYNAMIC_SLOT]: [number, string, string[]]
@@ -399,6 +411,9 @@ export const MessageChannelDataSide = (
       case ChannelEventType.INTERSECTION_OBSERVER_CALLBACK:
         id2callback<Channel['createMediaQueryObserver']>(arg[1], false)?.(JSON.parse(arg[2]))
         break
+      case ChannelEventType.RESIZE_OBSERVER_CALLBACK:
+        id2callback<Channel['createResizeObserver']>(arg[1], false)?.(JSON.parse(arg[2]))
+        break
       case ChannelEventType.SET_MODEL_BINDING_STAT_CALLBACK:
         id2callback<Channel['setModelBindingStat']>(arg[1])!(JSON.parse(arg[2]))
         break
@@ -480,6 +495,9 @@ export const MessageChannelDataSide = (
         id2callback<Channel['startOverlayInspect']>(arg[1], false)?.(arg[2], arg[3])
         break
       }
+      case ChannelEventType.MANIPULATE_NATIVE_NODE_CALLBACK:
+        id2callback<Channel['manipulateNativeNode']>(arg[1])!(JSON.parse(arg[2]))
+        break
       case ChannelEventType.PERFORMANCE_STATS_CALLBACK: {
         id2callback<Channel['performanceEndTrace']>(arg[1])!({
           startTimestamp: arg[2],
@@ -561,6 +579,15 @@ export const MessageChannelDataSide = (
     ) => {
       const id = callback2id(listener)
       publish([ChannelEventType.CREATE_INTERSECTION_OBSERVER, target, relativeElement, relativeElementMargin, thresholds, id])
+      return id
+    },
+    createResizeObserver: (
+      target: number,
+      mode: GlassEaselBackend.ResizeObserverMode,
+      listener: (res: GlassEaselBackend.ResizeStatus) => void,
+    ) => {
+      const id = callback2id(listener)
+      publish([ChannelEventType.CREATE_RESIZE_OBSERVER, target, mode, id])
       return id
     },
     disconnectObserver: (id: number) => {
@@ -663,6 +690,17 @@ export const MessageChannelDataSide = (
       overlayInspectCallbackId = null
       publish([ChannelEventType.STOP_OVERLAY_INSPECT])
     },
+    triggerNativeEvent: (
+      elementId: number,
+      eventName: string,
+      detail: unknown,
+    ) => publish([ChannelEventType.TRIGGER_NATIVE_EVENT, elementId, eventName, JSON.stringify(detail)]),
+    manipulateNativeNode: (
+      elementId: number,
+      action: string,
+      args: unknown,
+      cb: (res: unknown) => void,
+    ) => publish([ChannelEventType.MANIPULATE_NATIVE_NODE, elementId, action, JSON.stringify(args), callback2id(cb)]),
 
     performanceStartTrace: (index: number) => publish([ChannelEventType.PERFORMANCE_START_TRACE, index]),
     performanceEndTrace: (id: number, cb: (stats: { startTimestamp: number; endTimestamp: number }) => void,) => publish([ChannelEventType.PERFORMANCE_END_TRACE, id, callback2id(cb)]),
@@ -894,6 +932,15 @@ export const MessageChannelViewSide = (
             ])
           },
         )
+        observersMap[callbackId] = observer
+        break
+      }
+      case ChannelEventType.CREATE_RESIZE_OBSERVER: {
+        const [, targetId, mode, callbackId] = arg
+        const target = nodeMap[targetId] as Element
+        const observer = controller.createResizeObserver(target, mode, (res) => {
+          publish([ChannelEventType.RESIZE_OBSERVER_CALLBACK, callbackId, JSON.stringify(res)])
+        })
         observersMap[callbackId] = observer
         break
       }
@@ -1304,6 +1351,24 @@ export const MessageChannelViewSide = (
       }
       case ChannelEventType.STOP_OVERLAY_INSPECT: {
         controller.stopOverlayInspect()
+        break
+      }
+      case ChannelEventType.TRIGGER_NATIVE_EVENT: {
+        const [, elementId, event, detail] = arg
+        const element = nodeMap[elementId]! as Element
+        controller.triggerNativeEvent(element, event, JSON.parse(detail))
+        break
+      }
+      case ChannelEventType.MANIPULATE_NATIVE_NODE: {
+        const [, elementId, action, args, callbackId] = arg
+        const element = nodeMap[elementId]! as Element
+        controller.manipulateNativeNode(element, action, JSON.parse(args), (res) => {
+          publish([
+            ChannelEventType.MANIPULATE_NATIVE_NODE_CALLBACK,
+            callbackId,
+            JSON.stringify(res),
+          ])
+        })
         break
       }
       case ChannelEventType.PERFORMANCE_START_TRACE: {

--- a/glass-easel-shadow-sync/src/view_controller.ts
+++ b/glass-easel-shadow-sync/src/view_controller.ts
@@ -25,9 +25,16 @@ import { dashToCamelCase, initValues, updateValues } from './utils'
 // eslint-disable-next-line @typescript-eslint/ban-types
 type OptionalKeys<T> = { [P in keyof T]-?: {} extends Pick<T, P> ? P : never }[keyof T]
 
+type NormalFunction<Args extends any[], Ret> = (...args: Args) => Ret
 type CallbackFunction<Args extends any[], Ret> = (...args: [...Args, (ret: Ret) => void]) => void
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ParametersOrNever<T> = T extends CallbackFunction<infer Arg, infer Ret> ? Arg : never
+type CallbackParametersOrNever<T> = T extends CallbackFunction<infer Arg, infer Ret>
+  ? Arg
+  : T extends NormalFunction<infer Arg, infer Ret>
+  ? Arg
+  : never
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ParametersOrNever<T> = T extends NormalFunction<infer Arg, infer Ret> ? Arg : never
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type DefaultReturn<T> = T extends CallbackFunction<infer Arg, infer Ret> ? Ret : never
 
@@ -165,6 +172,14 @@ export class ViewController {
         listener,
       ) ?? undefined
     )
+  }
+
+  createResizeObserver(
+    target: Element,
+    mode: GlassEaselBackend.ResizeObserverMode,
+    listener: (res: GlassEaselBackend.ResizeStatus) => void,
+  ): GlassEaselBackend.Observer | undefined {
+    return target.createResizeObserver(mode, listener) ?? undefined
   }
 
   createElement(logicalName: string, stylingName: string, ownerShadowRoot: ShadowRoot): Element {
@@ -476,6 +491,31 @@ export class ViewController {
     element: Element,
     method: M,
     args: ParametersOrNever<GlassEaselBackend.Element[M]>,
+  ): void {
+    const { _glassEasel } = this
+    const backendContext = element.getBackendContext()
+    const backendElement = element.getBackendElement()
+    if (!backendContext || !backendElement) {
+      return
+    }
+    if (backendContext.mode === _glassEasel.BackendMode.Domlike) {
+      if (!(backendContext as any)[method]) {
+        return
+      }
+      ;(backendContext as any)[method](backendElement as domlikeBackend.Element, ...args)
+    } else {
+      const be = backendElement as composedBackend.Element | shadowBackend.Element
+      if (!be[method]) {
+        return
+      }
+      ;(be as any)[method](...args)
+    }
+  }
+
+  private callSuggestedBackendCbMethod<M extends OptionalKeys<GlassEaselBackend.Element>>(
+    element: Element,
+    method: M,
+    args: CallbackParametersOrNever<GlassEaselBackend.Element[M]>,
     defaultReturn: DefaultReturn<GlassEaselBackend.Element[M]>,
     cb: (res: DefaultReturn<GlassEaselBackend.Element[M]>) => void,
   ): void {
@@ -503,7 +543,7 @@ export class ViewController {
     element: Element,
     cb: (res: GlassEaselBackend.GetAllComputedStylesResponses) => void,
   ): void {
-    this.callSuggestedBackendMethod(element, 'getAllComputedStyles', [], { properties: [] }, cb)
+    this.callSuggestedBackendCbMethod(element, 'getAllComputedStyles', [], { properties: [] }, cb)
   }
 
   getPseudoComputedStyles(
@@ -511,7 +551,7 @@ export class ViewController {
     pseudoType: string,
     cb: (res: GlassEaselBackend.GetAllComputedStylesResponses) => void,
   ): void {
-    this.callSuggestedBackendMethod(
+    this.callSuggestedBackendCbMethod(
       element,
       'getPseudoComputedStyles',
       [pseudoType],
@@ -524,7 +564,7 @@ export class ViewController {
     element: Element,
     cb: (res: GlassEaselBackend.GetInheritedRulesResponses) => void,
   ): void {
-    this.callSuggestedBackendMethod(element, 'getInheritedRules', [], { rules: [] }, cb)
+    this.callSuggestedBackendCbMethod(element, 'getInheritedRules', [], { rules: [] }, cb)
   }
 
   replaceStyleSheetAllProperties(
@@ -550,12 +590,14 @@ export class ViewController {
 
   getBoxModel(
     element: Element,
-    cb: (res: {
-      margin: GlassEaselBackend.BoundingClientRect
-      border: GlassEaselBackend.BoundingClientRect
-      padding: GlassEaselBackend.BoundingClientRect
-      content: GlassEaselBackend.BoundingClientRect
-    }) => void,
+    cb: (
+      res: {
+        margin: GlassEaselBackend.BoundingClientRect
+        border: GlassEaselBackend.BoundingClientRect
+        padding: GlassEaselBackend.BoundingClientRect
+        content: GlassEaselBackend.BoundingClientRect
+      } | null,
+    ) => void,
   ): void {
     const mockRect = { left: 0, top: 0, width: 0, height: 0 }
     const mockBoxModel = {
@@ -564,14 +606,14 @@ export class ViewController {
       padding: mockRect,
       content: mockRect,
     }
-    this.callSuggestedBackendMethod(element, 'getBoxModel', [], mockBoxModel, cb)
+    this.callSuggestedBackendCbMethod(element, 'getBoxModel', [], mockBoxModel, cb)
   }
 
   getMatchedRules(
     element: Element,
     cb: (res: GlassEaselBackend.GetMatchedRulesResponses) => void,
   ): void {
-    this.callSuggestedBackendMethod(element, 'getMatchedRules', [], { inline: [], rules: [] }, cb)
+    this.callSuggestedBackendCbMethod(element, 'getMatchedRules', [], { inline: [], rules: [] }, cb)
   }
 
   getScrollOffset(
@@ -618,11 +660,11 @@ export class ViewController {
   }
 
   getContext(element: Element, cb: (res: any) => void): void {
-    this.callSuggestedBackendMethod(element, 'getContext', [], null, cb)
+    this.callSuggestedBackendCbMethod(element, 'getContext', [], null, cb)
   }
 
   getPseudoTypes(element: Element, cb: (res: string[]) => void): void {
-    this.callSuggestedBackendMethod(element, 'getPseudoTypes', [], [], cb)
+    this.callSuggestedBackendCbMethod(element, 'getPseudoTypes', [], [], cb)
   }
 
   startOverlayInspect(callback: (event: string, node: Element | null) => void): void {
@@ -639,6 +681,25 @@ export class ViewController {
       return
     }
     _backendContext.stopOverlayInspect()
+  }
+
+  triggerNativeEvent(element: Element, type: string, detail: unknown): void {
+    this.callSuggestedBackendMethod(element, 'triggerNativeEvent', [type, detail])
+  }
+
+  manipulateNativeNode(
+    element: Element,
+    action: string,
+    args: unknown,
+    callback: (res: unknown) => void,
+  ): void {
+    this.callSuggestedBackendCbMethod(
+      element,
+      'manipulateNativeNode',
+      [action, args],
+      null,
+      callback,
+    )
   }
 
   setListenerStats(

--- a/glass-easel/src/backend/suggested_backend_protocol.ts
+++ b/glass-easel/src/backend/suggested_backend_protocol.ts
@@ -26,12 +26,14 @@ export type Element<E> = {
   ): void
   getBoundingClientRect(cb: (res: BoundingClientRect) => void): void
   getBoxModel(
-    cb: (res: {
-      margin: BoundingClientRect
-      border: BoundingClientRect
-      padding: BoundingClientRect
-      content: BoundingClientRect
-    }) => void,
+    cb: (
+      res: {
+        margin: BoundingClientRect
+        border: BoundingClientRect
+        padding: BoundingClientRect
+        content: BoundingClientRect
+      } | null,
+    ) => void,
   ): void
   createIntersectionObserver(
     relativeElement: E | null,
@@ -47,6 +49,8 @@ export type Element<E> = {
   setScrollPosition(scrollLeft: number, scrollTop: number, duration: number): void
   getContext(cb: (res: unknown) => void): void
   getPseudoTypes(cb: (res: string[]) => void): void
+  triggerNativeEvent(type: string, detail: unknown): void
+  manipulateNativeNode(action: string, args: unknown, cb: (res: unknown) => void): void
 }
 
 export type ElementForDomLike = {

--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -613,6 +613,7 @@ export class Component<
       }
     }
     comp._$initialize(
+      def.is,
       virtualHost,
       backendElement,
       owner,
@@ -1037,10 +1038,6 @@ export class Component<
       null,
       initPropValues,
     )
-  }
-
-  get is(): string {
-    return this._$definition.is
   }
 
   get properties(): Merge<DataWithPropertyValues<TData, TProperty>> {

--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -108,6 +108,7 @@ export type DoubleLinkedList<T> = {
  */
 export class Element implements NodeCast {
   [ELEMENT_SYMBOL]: true
+  public is: string
   /** @internal */
   _$backendElement: GeneralBackendElement | null
   /** @internal */
@@ -169,11 +170,13 @@ export class Element implements NodeCast {
 
   /* @internal */
   protected _$initialize(
+    is: string,
     virtual: boolean,
     backendElement: GeneralBackendElement | null,
     owner: ShadowRoot | null,
     nodeTreeContext: GeneralBackendContext | DestroyedBackendContext,
   ) {
+    this.is = is
     this._$backendElement = backendElement
     this._$destroyOnRemoval = AutoDestroyState.Disabled
     this._$nodeTreeContext = nodeTreeContext

--- a/glass-easel/src/element_iterator.ts
+++ b/glass-easel/src/element_iterator.ts
@@ -93,11 +93,6 @@ export class ElementIterator<T extends Node = Element> {
   static create(
     node: Node,
     type: ElementIteratorType,
-    nodeTypeLimit?: typeof Element,
-  ): ElementIterator<Element>
-  static create(
-    node: Node,
-    type: ElementIteratorType,
     nodeTypeLimit: typeof Component,
   ): ElementIterator<GeneralComponent>
   static create(
@@ -115,6 +110,11 @@ export class ElementIterator<T extends Node = Element> {
     type: ElementIteratorType,
     nodeTypeLimit: typeof VirtualNode,
   ): ElementIterator<VirtualNode>
+  static create(
+    node: Node,
+    type: ElementIteratorType,
+    nodeTypeLimit?: typeof Element,
+  ): ElementIterator<Element>
   static create(
     node: Node,
     type: ElementIteratorType,

--- a/glass-easel/src/native_node.ts
+++ b/glass-easel/src/native_node.ts
@@ -16,7 +16,6 @@ import { NATIVE_NODE_SYMBOL, isNativeNode } from './type_symbol'
 
 export class NativeNode extends Element {
   [NATIVE_NODE_SYMBOL]: true
-  is: string
   public stylingName: string
   /* @internal */
   private _$modelBindingListeners?: { [name: string]: ModelBindingListener }
@@ -34,7 +33,6 @@ export class NativeNode extends Element {
   /* @internal */
   static create(tagName: string, owner: ShadowRoot, stylingName?: string): NativeNode {
     const node = Object.create(NativeNode.prototype) as NativeNode
-    node.is = tagName
     node.stylingName = stylingName ?? tagName
     const nodeTreeContext = owner.getBackendContext()
     let backendElement: GeneralBackendElement | null = null
@@ -50,7 +48,7 @@ export class NativeNode extends Element {
       }
       if (ENV.DEV) performanceMeasureEnd()
     }
-    node._$initialize(false, backendElement, owner, owner._$nodeTreeContext)
+    node._$initialize(tagName, false, backendElement, owner, owner._$nodeTreeContext)
     const ownerHost = owner.getHostNode()
     const [styleScope, extraStyleScope, styleScopeManager] = ownerHost.getStyleScopes()
     node.classList = new ClassList(

--- a/glass-easel/src/shadow_root.ts
+++ b/glass-easel/src/shadow_root.ts
@@ -82,7 +82,6 @@ export class ShadowRoot extends VirtualNode {
       be = (host._$backendElement as backend.Element).getShadowRoot()!
     }
 
-    node.is = 'shadow'
     node._$idMap = null
     let slotMode = SlotMode.Single
     const hostComponentOptions = host.getComponentOptions()
@@ -105,7 +104,7 @@ export class ShadowRoot extends VirtualNode {
       node._$updateDynamicSlotValueHandler = undefined
     }
     node._$backendShadowRoot = be
-    node._$initialize(true, be, node, host._$nodeTreeContext)
+    node._$initialize('shadow', true, be, node, host._$nodeTreeContext)
     node._$host = host
     node._$hooks = host.getOwnerSpace().hooks
     host.shadowRoot = node

--- a/glass-easel/src/virtual_node.ts
+++ b/glass-easel/src/virtual_node.ts
@@ -7,7 +7,6 @@ import { VIRTUAL_NODE_SYMBOL, isVirtualNode } from './type_symbol'
 
 export class VirtualNode extends Element {
   [VIRTUAL_NODE_SYMBOL]: true
-  is: string
 
   /* @internal */
   /* istanbul ignore next */
@@ -23,7 +22,7 @@ export class VirtualNode extends Element {
     owner: ShadowRoot,
     nodeTreeContext: GeneralBackendContext | null,
   ) {
-    this.is = String(virtualName)
+    const is = String(virtualName)
     if (
       nodeTreeContext &&
       (BM.SHADOW || (BM.DYNAMIC && nodeTreeContext.mode === BackendMode.Shadow))
@@ -32,13 +31,13 @@ export class VirtualNode extends Element {
       if (ENV.DEV) performanceMeasureStart('backend.createVirtualNode')
       const be = shadowRoot.createVirtualNode(virtualName)
       if (ENV.DEV) performanceMeasureEnd()
-      this._$initialize(true, be, owner, nodeTreeContext)
+      this._$initialize(is, true, be, owner, nodeTreeContext)
       if (ENV.DEV) performanceMeasureStart('backend.associateValue')
       be.__wxElement = this
       be.associateValue(this)
       if (ENV.DEV) performanceMeasureEnd()
     } else {
-      this._$initialize(true, null, owner, owner._$nodeTreeContext)
+      this._$initialize(is, true, null, owner, owner._$nodeTreeContext)
     }
   }
 


### PR DESCRIPTION
## Summary

- Move the `is` property from `NativeNode`/`VirtualNode` subclasses to the base Element class, passing it through `_$initialize()` for a unified access pattern.
- Add `triggerNativeEvent`, `manipulateNativeNode`, and `createResizeObserver` support across the backend protocol, shadow-sync backend, message channel, and view controller.
