### PR TITLE
fix(core): preserve binding map after placeholder replacement

### DIFF
--- a/glass-easel-template-compiler/src/proc_gen/tag.rs
+++ b/glass-easel-template-compiler/src/proc_gen/tag.rs
@@ -61,7 +61,7 @@ impl Template {
                      has_scripts: bool| {
                         w.expr_stmt(|w| {
                             write!(w, "H[{key}]=", key = gen_lit_str(key))?;
-                            w.function_args("R,C,D,U", |w| {
+                            w.function_args("R,C,D,U,A", |w| {
                                 if has_scripts {
                                     w.expr_stmt(|w| {
                                         write!(w, "R.setFnFilter(Q.A,Q.B)")?;
@@ -86,8 +86,8 @@ impl Template {
                                     declare_shortcut!("L", "R.c");
                                     declare_shortcut!("M", "R.m");
                                     declare_shortcut!("O", "R.r");
-                                    w.set_var_on_top_scope_init("A", |w| {
-                                        write!(w, "{{")?;
+                                    w.expr_stmt(|w| {
+                                        write!(w, "A=A||{{")?;
                                         for (index, (key, size)) in bmc.list_fields().enumerate() {
                                             if index > 0 {
                                                 write!(w, ",")?;

--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -2488,7 +2488,10 @@ export class Element implements NodeCast {
     }
   }
 
-  getListeners(): Record<string, (EventListenerOptions & { listener: EventListener<unknown> })[]> {
+  getListeners(): Record<
+    string,
+    (Required<EventListenerOptions> & { listener: EventListener<unknown> })[]
+  > {
     return this._$eventTarget.getListeners()
   }
 

--- a/glass-easel/src/event.ts
+++ b/glass-easel/src/event.ts
@@ -172,7 +172,7 @@ export class EventTarget<TEvents extends { [type: string]: unknown }> {
   getListeners() {
     const finalListeners = Object.create(null) as Record<
       string,
-      (EventListenerOptions & { listener: EventListener<unknown> })[]
+      (Required<EventListenerOptions> & { listener: EventListener<unknown> })[]
     >
     const resolveListeners = (
       listeners: { [T in keyof TEvents]: EventFuncArr<TEvents[T]> },

--- a/glass-easel/src/tmpl/index.ts
+++ b/glass-easel/src/tmpl/index.ts
@@ -23,11 +23,11 @@ export {
   type ChangePropFilter,
 } from './proc_gen_wrapper'
 
-const DEFAULT_PROC_GEN: ProcGen = () => ({
+const DEFAULT_PROC_GEN: ProcGen = (R, C, D, U?, A?) => ({
   C: (isCreation, defineTextNode, defineElement, defineIfGroup, defineForLoop, defineSlot) => {
     defineSlot('')
   },
-  B: Object.create(null) as { [field: string]: BindingMapGen[] },
+  B: (A || Object.create(null)) as { [field: string]: BindingMapGen[] },
 })
 export const DEFAULT_PROC_GEN_GROUP: (name: string) => ProcGen = () => DEFAULT_PROC_GEN
 
@@ -230,7 +230,22 @@ export class GlassEaselTemplateInstance implements TemplateInstance {
         }
       }
     }
-    this.procGenWrapper.update(data, dataUpdatePathTree)
+    const oldBindingMapGen = this.bindingMapGen
+    const bindingMapGen = (this.bindingMapGen =
+      this.procGenWrapper.update(data, dataUpdatePathTree, oldBindingMapGen) || oldBindingMapGen)
+    // FIXME: this is a temporary solution for older version of template compiler
+    // procGen will return fresh new bindingMapGen each time
+    // we need to use the new one but it may contain undefined items
+    if (oldBindingMapGen && bindingMapGen && oldBindingMapGen !== bindingMapGen) {
+      const keys = Object.keys(bindingMapGen)
+      for (let i = 0; i < keys.length; i += 1) {
+        const key = keys[i]!
+        const updators = bindingMapGen[key]!
+        for (let j = 0; j < updators.length; j += 1) {
+          if (!updators[j]) updators[j] = oldBindingMapGen[key]![j]!
+        }
+      }
+    }
   }
 
   tryBindingMapUpdate(data: DataValue, change?: DataChange): boolean {

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -119,7 +119,8 @@ export interface ProcGen {
     isCreation: false,
     data: DataValue,
     dataUpdatePathTree: UpdatePathTreeNode,
-  ): { C: DefineChildren }
+    bindingMapGenList: { [field: string]: BindingMapGen[] } | undefined,
+  ): { C: DefineChildren; B?: { [field: string]: BindingMapGen[] } }
 }
 
 export type ProcGenEnv = {
@@ -208,10 +209,15 @@ export class ProcGenWrapper {
     return children.B
   }
 
-  update(data: DataValue, dataUpdatePathTree: UpdatePathTreeNode): void {
+  update(
+    data: DataValue,
+    dataUpdatePathTree: UpdatePathTreeNode,
+    bindingMapGen: { [field: string]: BindingMapGen[] } | undefined,
+  ): { [field: string]: BindingMapGen[] } | undefined {
     const { shadowRoot, procGen } = this
-    const children = procGen(this, false, data, dataUpdatePathTree)
+    const children = procGen(this, false, data, dataUpdatePathTree, bindingMapGen)
     this.handleChildrenUpdate(children.C, shadowRoot, undefined, undefined)
+    return children.B
   }
 
   private endBindingMapUpdateForElement(elem: Element) {

--- a/glass-easel/tests/core/placeholder.test.ts
+++ b/glass-easel/tests/core/placeholder.test.ts
@@ -579,6 +579,59 @@ const testCases = (testBackend: glassEasel.GeneralBackendContext) => {
     expect(domHtml(elem)).toBe('<div>1-1-1</div><div>2-2-2</div><div>3-3-3</div><div>4-4-4</div>')
     matchElementWithDom(elem)
   })
+
+  test('binding map update after replacing', () => {
+    const cs = new glassEasel.ComponentSpace()
+
+    const Root = cs.defineComponent({
+      using: {
+        child: 'child',
+      },
+      placeholders: {
+        child: 'div',
+      },
+      template: tmpl(`
+        <child visible="{{visible}}"></child>
+      `),
+      data: {
+        visible: false,
+      },
+    })
+    const elem = glassEasel.Component.createWithContext('root', Root, testBackend)
+    glassEasel.Element.pretendAttached(elem)
+
+    expect(domHtml(elem)).toBe('<div></div>')
+    matchElementWithDom(elem)
+
+    // update something
+    elem.setData({ a: 1, b: 2 } as any)
+
+    const callOrder: boolean[] = []
+
+    cs.defineComponent({
+      is: 'child',
+      template: tmpl(`
+        <div>{{visible}}</div>
+      `),
+      properties: {
+        visible: {
+          type: Boolean,
+          observer: (val: boolean) => {
+            callOrder.push(val)
+          },
+        },
+      },
+    })
+
+    expect(callOrder).toStrictEqual([])
+    expect(domHtml(elem)).toBe('<child><div>false</div></child>')
+    matchElementWithDom(elem)
+
+    elem.setData({ visible: true })
+    expect(callOrder).toStrictEqual([true])
+    expect(domHtml(elem)).toBe('<child><div>true</div></child>')
+    matchElementWithDom(elem)
+  })
 }
 
 describe('placeholder (DOM backend)', () => testCases(domBackend))


### PR DESCRIPTION
When a placeholder component is replaced with the real component, the proc gen returns a fresh binding map that may contain undefined slots. Merge it with the previous binding map so existing updaters keep working.