### PR TITLE
refactor: Refactoring placeholder replacement logic and adding back p…

### DIFF
--- a/glass-easel/src/component.ts
+++ b/glass-easel/src/component.ts
@@ -524,6 +524,7 @@ export class Component<
     owner: ShadowRoot | null,
     backendContext: GeneralBackendContext | null,
     genericImpls: { [name: string]: ComponentDefinitionWithPlaceholder } | null,
+    placeholderHandlerRemover: (() => void) | undefined,
     initPropValues?: (comp: ComponentInstance<TData, TProperty, TMethod>) => void,
   ): ComponentInstance<TData, TProperty, TMethod> {
     if (!def._$detail) {
@@ -620,6 +621,7 @@ export class Component<
       owner,
       owner?._$nodeTreeContext ?? nodeTreeContext!,
     )
+    comp._$placeholderHandlerRemover = placeholderHandlerRemover
 
     const ownerHost = owner ? owner.getHostNode() : undefined
 
@@ -965,6 +967,7 @@ export class Component<
         null,
         backendContext,
         collectGenericImpls(componentDefinition as unknown as GeneralComponentDefinition),
+        undefined,
         initPropValues,
       )
     }

--- a/glass-easel/src/element.ts
+++ b/glass-easel/src/element.ts
@@ -134,6 +134,8 @@ export class Element implements NodeCast {
   /** @internal */
   _$inheritSlots: boolean
   /** @internal */
+  _$placeholderHandlerRemover: (() => void) | undefined
+  /** @internal */
   _$virtual: boolean
   dataset: { [name: string]: unknown }
   /** @internal */
@@ -189,6 +191,7 @@ export class Element implements NodeCast {
     this._$subtreeSlotStart = null
     this._$subtreeSlotEnd = null
     this._$inheritSlots = false
+    this._$placeholderHandlerRemover = undefined
     this._$virtual = virtual
     this.dataset = {}
     this._$marks = null
@@ -676,6 +679,8 @@ export class Element implements NodeCast {
           elem._$destroyOnRemoval = AutoDestroyState.Destroyed
           elem.destroyBackendElement()
         }
+        const f = elem._$placeholderHandlerRemover
+        if (typeof f === 'function') f()
       }
       rec(node)
     } else if (node._$destroyOnRemoval === AutoDestroyState.Enabled) {
@@ -865,7 +870,7 @@ export class Element implements NodeCast {
       cur = cur.parentNode
     }
     if (isComponent(cur) && cur._$external) {
-      return (cur.shadowRoot as ExternalShadowRoot).slot as composedElement
+      return (cur.shadowRoot as ExternalShadowRoot).slot as composedElement | null
     }
     return cur ? (cur._$backendElement as composedElement) : null
   }

--- a/glass-easel/src/event.ts
+++ b/glass-easel/src/event.ts
@@ -443,7 +443,7 @@ export class Event<TDetail> {
       forEachBubblePath(target, (currentTarget, target, mark) => {
         if (!atTarget && isComponent(currentTarget) && currentTarget._$external) {
           const sr = currentTarget.shadowRoot as ExternalShadowRoot
-          sr.handleEvent(sr.slot, this)
+          if (sr.slot) sr.handleEvent(sr.slot, this)
         }
         atTarget = false
 

--- a/glass-easel/src/external_shadow_tree.ts
+++ b/glass-easel/src/external_shadow_tree.ts
@@ -10,8 +10,8 @@ import { type GeneralBackendElement } from './backend'
  * However, the subtree must be created in the same backend context.
  */
 export interface ExternalShadowRoot {
-  root: GeneralBackendElement
-  slot: GeneralBackendElement
+  root: GeneralBackendElement | null
+  slot: GeneralBackendElement | null
   getIdMap(): { [id: string]: GeneralBackendElement }
   handleEvent<T>(target: GeneralBackendElement, event: Event<T>): void
   setListener<T>(

--- a/glass-easel/src/native_node.ts
+++ b/glass-easel/src/native_node.ts
@@ -31,7 +31,12 @@ export class NativeNode extends Element {
   static isNativeNode = isNativeNode
 
   /* @internal */
-  static create(tagName: string, owner: ShadowRoot, stylingName?: string): NativeNode {
+  static create(
+    tagName: string,
+    owner: ShadowRoot,
+    stylingName?: string,
+    placeholderHandlerRemover?: () => void,
+  ): NativeNode {
     const node = Object.create(NativeNode.prototype) as NativeNode
     node.stylingName = stylingName ?? tagName
     const nodeTreeContext = owner.getBackendContext()
@@ -49,6 +54,7 @@ export class NativeNode extends Element {
       if (ENV.DEV) performanceMeasureEnd()
     }
     node._$initialize(tagName, false, backendElement, owner, owner._$nodeTreeContext)
+    node._$placeholderHandlerRemover = placeholderHandlerRemover
     const ownerHost = owner.getHostNode()
     const [styleScope, extraStyleScope, styleScopeManager] = ownerHost.getStyleScopes()
     node.classList = new ClassList(

--- a/glass-easel/src/shadow_root.ts
+++ b/glass-easel/src/shadow_root.ts
@@ -1,4 +1,5 @@
 import { BM, BackendMode, type backend } from './backend'
+import { type ComponentDefinitionWithPlaceholder } from './behavior'
 import {
   Component,
   convertGenerics,
@@ -6,7 +7,7 @@ import {
   type GeneralComponent,
   type GeneralComponentDefinition,
 } from './component'
-import { type ComponentSpaceHooks } from './component_space'
+import { type ComponentWaitingList, type ComponentSpaceHooks } from './component_space'
 import { DeepCopyStrategy, getDeepCopyStrategy } from './data_proxy'
 import { deepCopy, simpleDeepCopy } from './data_utils'
 import { Element, type DoubleLinkedList } from './element'
@@ -14,9 +15,9 @@ import { MutationObserverTarget } from './mutation_observer'
 import { NativeNode } from './native_node'
 import { type Node } from './node'
 import { TextNode } from './text_node'
-import { SHADOW_ROOT_SYMBOL, isElement, isShadowRoot } from './type_symbol'
+import { SHADOW_ROOT_SYMBOL, isComponent, isElement, isShadowRoot } from './type_symbol'
 import { VirtualNode } from './virtual_node'
-import { ThirdError, triggerWarning } from './warning'
+import { ThirdError, dispatchError, triggerWarning } from './warning'
 
 export const enum SlotMode {
   Single = 1,
@@ -141,11 +142,13 @@ export class ShadowRoot extends VirtualNode {
   createNativeNodeWithInit(
     tagName: string,
     stylingName: string,
+    placeholderHandlerRemover: (() => void) | undefined,
     initPropValues?: (comp: NativeNode) => void,
   ): NativeNode {
     const ret = this._$hooks.createNativeNode.call(
       this,
-      (tagName, stylingName) => NativeNode.create(tagName, this, stylingName),
+      (tagName, stylingName) =>
+        NativeNode.create(tagName, this, stylingName, placeholderHandlerRemover),
       tagName,
       stylingName,
     )
@@ -158,7 +161,7 @@ export class ShadowRoot extends VirtualNode {
     usingKey?: string,
   ): {
     using: GeneralComponentDefinition | string
-    placeholderHandler: { onReplace(callback: () => void): void; destroy: () => void } | undefined
+    waiting?: ComponentWaitingList
   } {
     const host = this._$host
     const beh = host._$behavior
@@ -176,32 +179,12 @@ export class ShadowRoot extends VirtualNode {
     for (let i = 0; i < possibleComponentDefinitions.length; i += 1) {
       const cwp = possibleComponentDefinitions[i]
       if (cwp === null || cwp === undefined) continue
-      if (typeof cwp === 'string') return { using: cwp, placeholderHandler: undefined }
-      if (cwp.final) return { using: cwp.final, placeholderHandler: undefined }
+      if (typeof cwp === 'string') return { using: cwp, waiting: undefined }
+      if (cwp.final) return { using: cwp.final, waiting: undefined }
       if (cwp.placeholder !== null) {
         const placeholder = resolvePlaceholder(cwp.placeholder, space, cwp.source, hostGenericImpls)
         const waiting = cwp.waiting || undefined
-        if (waiting) {
-          let placeholderCallback: (() => void) | undefined
-          const actualPlaceholderCallback = () => {
-            placeholderCallback?.()
-            placeholderCallback = undefined
-          }
-          waiting.add(actualPlaceholderCallback)
-          waiting.hintUsed(host)
-          return {
-            using: placeholder,
-            placeholderHandler: {
-              onReplace(callback: () => void) {
-                placeholderCallback = callback
-              },
-              destroy() {
-                waiting.remove(actualPlaceholderCallback)
-              },
-            },
-          }
-        }
-        return { using: placeholder, placeholderHandler: undefined }
+        return { using: placeholder, waiting }
       }
     }
 
@@ -218,7 +201,7 @@ export class ShadowRoot extends VirtualNode {
       }
       triggerWarning(`Cannot find component "${compName}", using default component.`, this._$host)
     }
-    return { using: comp, placeholderHandler: undefined }
+    return { using: comp, waiting: undefined }
   }
 
   /**
@@ -231,29 +214,67 @@ export class ShadowRoot extends VirtualNode {
     tagName: string,
     usingKey?: string,
     genericTargets?: { [key: string]: string },
+    placeholderCallback?: ((c: GeneralComponentDefinition) => void) | undefined,
     initPropValues?: (comp: GeneralComponent | NativeNode) => void,
   ): GeneralComponent | NativeNode {
     const host = this._$host
     const beh = host._$behavior
-    const { using } = this.resolveComponent(tagName, usingKey)
+    const { using, waiting } = this.resolveComponent(tagName, usingKey)
 
-    const node =
-      typeof using === 'string'
-        ? this.createNativeNodeWithInit(using, tagName, initPropValues)
-        : this._$hooks.createComponent.call(
-            this,
-            (tagName, compDef) =>
-              Component._$advancedCreate(
-                tagName,
-                compDef,
-                this,
-                null,
-                convertGenerics(compDef, beh, host, genericTargets),
-                initPropValues,
-              ),
-            tagName,
-            using,
+    let placeholderHandlerRemover: (() => void) | undefined
+
+    if (waiting) {
+      // The resolved component is a placeholder — register a callback so that
+      // when the real component definition arrives, a replacer node is created
+      // and swapped in for the placeholder node in the tree.
+      const replacePlaceholderCallback = (c: GeneralComponentDefinition) => {
+        const replacer = this.createComponentByDef(
+          tagName,
+          c,
+          genericTargets,
+          undefined,
+          initPropValues,
+        )
+        replacer.destroyBackendElementOnRemoval()
+        const replacerShadowRoot = replacer.getShadowRoot()
+        const elemShadowRoot = isComponent(node) ? node.getShadowRoot() : null
+        const isElemDynamicSlots = elemShadowRoot?.getSlotMode() === SlotMode.Dynamic
+        const isReplacerDynamicSlots = replacerShadowRoot?.getSlotMode() === SlotMode.Dynamic
+        if (isReplacerDynamicSlots !== isElemDynamicSlots) {
+          // The `dynamicSlots` option must match between the placeholder and its
+          // real component, otherwise the slot layout would be inconsistent.
+          dispatchError(
+            new Error(
+              `The "dynamicSlots" option of component <${replacer.is}> and its placeholder <${node.is}> should be the same.`,
+            ),
+            '[render]',
+            replacer,
           )
+        } else if (isReplacerDynamicSlots) {
+          // Dynamic-slot components rely on the parent to reassign slot children,
+          // so replace through `parentNode.replaceChild` to trigger the update.
+          node.parentNode?.replaceChild(replacer, node)
+        } else {
+          node.selfReplaceWith(replacer)
+        }
+        placeholderCallback?.(c)
+      }
+      waiting.add(replacePlaceholderCallback)
+      waiting.hintUsed(this._$host)
+      // Store the deregister so that the callback can be removed when the
+      // element is later destroyed (see `Element._$placeholderHandlerRemover`).
+      placeholderHandlerRemover = () => {
+        waiting.remove(replacePlaceholderCallback)
+      }
+    }
+
+    const node = this.createComponentByDef(
+      tagName,
+      using,
+      genericTargets,
+      placeholderHandlerRemover,
+      initPropValues,
+    )
 
     return node
   }
@@ -262,30 +283,39 @@ export class ShadowRoot extends VirtualNode {
     tagName: string,
     componentDef: GeneralComponentDefinition,
     genericTargets?: { [key: string]: string },
+    placeholderHandlerRemover?: (() => void) | undefined,
     initPropValues?: (comp: GeneralComponent | NativeNode) => void,
   ): GeneralComponent
   createComponentByDef(
     tagName: string,
     componentDef: string,
     genericTargets?: { [key: string]: string },
+    placeholderHandlerRemover?: (() => void) | undefined,
     initPropValues?: (comp: GeneralComponent | NativeNode) => void,
   ): NativeNode
   createComponentByDef(
     tagName: string,
     componentDef: GeneralComponentDefinition | string,
     genericTargets?: { [key: string]: string },
+    placeholderHandlerRemover?: (() => void) | undefined,
     initPropValues?: (comp: GeneralComponent | NativeNode) => void,
   ): GeneralComponent | NativeNode
   createComponentByDef(
     tagName: string,
     componentDef: GeneralComponentDefinition | string,
     genericTargets?: { [key: string]: string },
+    placeholderHandlerRemover?: (() => void) | undefined,
     initPropValues?: (comp: GeneralComponent | NativeNode) => void,
   ): GeneralComponent | NativeNode {
     const host = this._$host
     const beh = host._$behavior
     return typeof componentDef === 'string'
-      ? this.createNativeNodeWithInit(componentDef, tagName, initPropValues)
+      ? this.createNativeNodeWithInit(
+          componentDef,
+          tagName,
+          placeholderHandlerRemover,
+          initPropValues,
+        )
       : this._$hooks.createComponent.call(
           this,
           (tagName, compDef) =>
@@ -295,11 +325,36 @@ export class ShadowRoot extends VirtualNode {
               this,
               null,
               convertGenerics(compDef, beh, host, genericTargets),
+              placeholderHandlerRemover,
               initPropValues,
             ),
           tagName,
           componentDef,
         )
+  }
+
+  /**
+   * Find whether this component is placeholding or not
+   *
+   * This method will only find in the component `using` list and `generics` list.
+   * If not found, returns `undefined` .
+   * If the placeholder will be used, returns `true` ; `false` otherwise.
+   */
+  checkComponentPlaceholder(usingKey: string): boolean | undefined {
+    const beh = this._$host._$behavior
+    let compDef: ComponentDefinitionWithPlaceholder
+    const using = beh._$using[usingKey]
+    if (using !== undefined) {
+      compDef = using
+    } else {
+      const g = this._$host._$genericImpls?.[usingKey]
+      if (g) compDef = g
+      else return undefined
+    }
+    if (typeof compDef === 'string') return false
+    if (compDef.final) return false
+    if (compDef.placeholder !== null) return true
+    return false
   }
 
   getElementById(id: string): Element | undefined {

--- a/glass-easel/src/tmpl/proc_gen_wrapper.ts
+++ b/glass-easel/src/tmpl/proc_gen_wrapper.ts
@@ -6,7 +6,6 @@ import { type DataValue } from '../data_proxy'
 import { Element, StyleSegmentIndex } from '../element'
 import { type EventListener } from '../event'
 import { safeCallback } from '../func_arr'
-import { MutationObserver } from '../mutation_observer'
 import { type NativeNode } from '../native_node'
 import { type Node } from '../node'
 import { SlotMode, type ShadowRoot } from '../shadow_root'
@@ -14,7 +13,7 @@ import { type TextNode } from '../text_node'
 import { type ProcGenGroupList } from '../tmpl'
 import { isComponent, isNativeNode } from '../type_symbol'
 import { type VirtualNode } from '../virtual_node'
-import { dispatchError, triggerWarning } from '../warning'
+import { triggerWarning } from '../warning'
 import { RangeListManager } from './range_list_diff'
 
 export type UpdatePathTreeNode = true | { [key: string]: UpdatePathTreeNode } | UpdatePathTreeNode[]
@@ -73,7 +72,9 @@ type TmplArgs = {
   staticClassesDirty?: boolean
   styleNameValues?: string[] // [name1, value1, name2, value2, ...]
   styleNameValuesDirty?: boolean
-  placeholderHandler?: { onReplace(callback: () => void): void; destroy: () => void }
+  // Set on placeholder elements; used to swap in the latest init-prop-values
+  // callback so that the replacer component is created with up-to-date data.
+  updateInitPropValues?: (cb: (elem: GeneralComponent | NativeNode) => void) => void
 }
 export type TmplDevArgs = {
   A?: string[] // active attributes
@@ -562,16 +563,12 @@ export class ProcGenWrapper {
         if (!dynSlot) {
           this.handleChildrenUpdate(children, elem, undefined, undefined)
         }
-        if (tmplArgs.placeholderHandler) {
-          tmplArgs.placeholderHandler.onReplace(
-            this.getPlaceholderCallback(
-              elem,
-              tagName,
-              genericImpls,
-              propertyInit,
-              children,
-              dynamicSlotValueNames,
-            ),
+        // If the element is still a placeholder, refresh the callback that
+        // initializes props on the future replacer component with the latest
+        // `propertyInit` / children / dynamic slot values captured in this pass.
+        if (tmplArgs.updateInitPropValues) {
+          tmplArgs.updateInitPropValues(
+            this.getInitPropValuesCallback(propertyInit, children, dynamicSlotValueNames),
           )
         }
       },
@@ -958,53 +955,22 @@ export class ProcGenWrapper {
     return true
   }
 
-  private getPlaceholderCallback(
-    elem: Element,
-    tagName: string,
-    genericImpls: { [key: string]: string },
+  private getInitPropValuesCallback(
     propertyInit: (elem: Element, isCreation: boolean) => void,
     children: DefineChildren,
     dynamicSlotValueNames: string[] | undefined,
-  ): () => void {
-    return () => {
-      const { using } = this.shadowRoot.resolveComponent(tagName, tagName)
-      const replacer = this.shadowRoot.createComponentByDef(
-        tagName,
-        using,
-        genericImpls,
-        (elem: GeneralComponent | NativeNode) => {
-          const sr = isComponent(elem)
-            ? this.dynamicSlotUpdate(elem, dynamicSlotValueNames, children)
-            : null
-          propertyInit(elem, true)
-          if (isComponent(elem)) {
-            if (elem.hasPendingChanges()) {
-              const nodeDataProxy = Component.getDataProxy(elem)
-              nodeDataProxy.applyDataUpdates(true)
-            }
-            sr?.applySlotUpdates()
-          }
-        },
-      )
-      replacer.destroyBackendElementOnRemoval()
-      const replacerShadowRoot = (replacer as GeneralComponent).getShadowRoot()
-      const elemShadowRoot = isComponent(elem) ? elem.getShadowRoot() : null
-      const isElemDynamicSlots = elemShadowRoot?.getSlotMode() === SlotMode.Dynamic
-      const isReplacerDynamicSlots = replacerShadowRoot?.getSlotMode() === SlotMode.Dynamic
-      if (isReplacerDynamicSlots !== isElemDynamicSlots) {
-        dispatchError(
-          new Error(
-            `The "dynamicSlots" option of component <${replacer.is}> and its placeholder <${
-              (elem as GeneralComponent).is
-            }> should be the same.`,
-          ),
-          '[render]',
-          isComponent(replacer) ? replacer : replacer.is,
-        )
-      } else if (isReplacerDynamicSlots) {
-        elem.parentNode?.replaceChild(replacer, elem)
-      } else {
-        elem.selfReplaceWith(replacer)
+  ): (elem: GeneralComponent | NativeNode) => void {
+    return (elem: GeneralComponent | NativeNode) => {
+      const sr = isComponent(elem)
+        ? this.dynamicSlotUpdate(elem, dynamicSlotValueNames, children)
+        : null
+      propertyInit(elem, true)
+      if (isComponent(elem)) {
+        if (elem.hasPendingChanges()) {
+          const nodeDataProxy = Component.getDataProxy(elem)
+          nodeDataProxy.applyDataUpdates(true)
+        }
+        sr?.applySlotUpdates()
       }
     }
   }
@@ -1016,42 +982,32 @@ export class ProcGenWrapper {
     children: DefineChildren,
     dynamicSlotValueNames: string[] | undefined,
   ): Element {
-    let dynSlot = false
-    const initPropValues = (elem: GeneralComponent | NativeNode) => {
-      const sr = isComponent(elem)
-        ? this.dynamicSlotUpdate(elem, dynamicSlotValueNames, children)
-        : null
-      if (sr) dynSlot = true
-      propertyInit(elem, true)
-      if (isComponent(elem)) {
-        if (elem.hasPendingChanges()) {
-          const nodeDataProxy = Component.getDataProxy(elem)
-          nodeDataProxy.applyDataUpdates(true)
-        }
-        sr?.applySlotUpdates()
+    // `initPropValues` is stored in a mutable binding so that it can be
+    // replaced from the update pass (see `tmplArgs.updateInitPropValues`
+    // below). This keeps the placeholder → real-component transition using
+    // the freshest data instead of the values captured at creation time.
+    let initPropValues = this.getInitPropValuesCallback(
+      propertyInit,
+      children,
+      dynamicSlotValueNames,
+    )
+    const elem = this.shadowRoot.createComponent(
+      tagName,
+      tagName,
+      genericImpls,
+      undefined,
+      (elem) => initPropValues(elem),
+    )
+    const placeholding = this.shadowRoot.checkComponentPlaceholder(tagName)
+    if (placeholding) {
+      // Expose a setter so that later template update passes can swap in a
+      // new `initPropValues`. The real-component replacement (registered
+      // inside `shadowRoot.createComponent`) will then use it.
+      getTmplArgs(elem).updateInitPropValues = (cb) => {
+        initPropValues = cb
       }
     }
-    const { placeholderHandler, using } = this.shadowRoot.resolveComponent(tagName, tagName)
-    const elem = this.shadowRoot.createComponentByDef(tagName, using, genericImpls, initPropValues)
-    if (placeholderHandler) {
-      const tmplArgs = getTmplArgs(elem)
-      tmplArgs.placeholderHandler = placeholderHandler
-      placeholderHandler.onReplace(
-        this.getPlaceholderCallback(
-          elem,
-          tagName,
-          genericImpls,
-          propertyInit,
-          children,
-          dynamicSlotValueNames,
-        ),
-      )
-      new MutationObserver((e) => {
-        if (e.type === 'attachStatus' && e.status === 'detached') {
-          placeholderHandler.destroy()
-        }
-      }).observe(elem, { attachStatus: true })
-    }
+    const dynSlot = isComponent(elem) && elem.getShadowRoot()?.getSlotMode() === SlotMode.Dynamic
     elem.destroyBackendElementOnRemoval()
     if (dynSlot) {
       this.bindingMapDisabled = true // IDEA better binding map disable detection


### PR DESCRIPTION
+ Refactoring placeholder replacement logic, moving it from `proc_gen_wrapper` to `ShadowRoot` for decoupling.
+ Re-adding the `placeholderCallback` parameter for `ShadowRoot.prototype.createComponent` and other APIs for backward compatibility.